### PR TITLE
Refactor implementation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,10 @@
 # Magnanimous
 
-The simplest and fastest static website generator in the world!!
+![Magnanimous mascot](website/source/static/images/mag-mid-logo.jpg)
+
+[https://renatoathaydes.github.io/magnanimous](https://renatoathaydes.github.io/magnanimous)
+
+The simplest and nicest static website generator in the world!!
 
 Magnanimous has the following guiding principles:
 
@@ -9,285 +13,27 @@ Magnanimous has the following guiding principles:
 * explicit is better than implicit.
 * generate static websites well, nothing else.
 
-This project is currently in early development and is not ready to be used. But stay tuned!
+## Features
+
+* simple templating mechanism based on a tiny [expression language](https://renatoathaydes.github.io/magnanimous/sections/docs/expression_lang.html)
+ (simple as `<p>2 + 2 is {{ eval 2 + 2 }}</p>`).
+* include file into another (`{{ include other-file.html }}`).
+* define variables (`{{ define title "Hello world" }}`).
+* [components](https://renatoathaydes.github.io/magnanimous/sections/docs/components.html) and slots inspired by web components.
+* conditional content (`{{ if title == "Home" }}We are home{{ end }}`).
+* for loops over files and variables (`{{ for file /path/to/files }}* Post name: {{eval file.postName}} {{end}}`).
+
+## Documentation
+
+Visit [the website](https://renatoathaydes.github.io/magnanimous) for the full documentation.
 
 ## Basic Design
 
 Magnanimous reads source files from the `source/` directory, and generates a website in `target/`.
 
-The following `source` sub-directories are the only ones treated specially by Magnanimous:
+The following `source` sub-directories are the only ones treated _specially_ by Magnanimous:
 
 * `source/static`    - static files that should be served as-is.
 * `source/processed` - files that will be processed, as explained below.
 
 Any other files and sub-directories are ignored by default, but may be referred to from processed files.
-
-### Processed files
-
-Files meant to be processed by Magnanimous are placed inside the `source/processed` directory.
-
-Processed files may use the following processor instructions:
-
-* `{{ include <path> }}` - include the contents of the file in the given path into the current file.
-* `{{ define <varible_name> <expression> }}` - define a variable.
-* `{{ eval <expression> }}` - evaluates an expression.
-* `{{ if <expression> }}` (conditional content) `{{ end }}`.
-* `{{ for <item> (sub-instructions) <iterable> }}` (repeated content for each item) `{{ end }}`.
-
-Markdown files (`*.md`) will be converted to HTML, after Magnanimous instructions are processed, using
-[Blackfriday](https://github.com/russross/blackfriday).
-
-Files whose name starts with `_` will not be present in the output website, but may be included by other files.
-
-#### Inclusions
-
-`include` instructions must always have a path to a file as an argument.
-
-An inclusion may look like this: 
-
-```
-{{ include /static/header.html }}
-```
-
-This whole expression will be replaced with the contents of the file at `source/static/header.html`.
-If the file does not exist, a warning will be emitted
-during compilation and the expression will appear as it is in the compiled resource.
-
-#### Variables
-
-Variables can be defined with the `define` instruction.
- 
-For example:
-
-```
-{{ define title "My Website" }}
-```
-
-The above instructions defines a variable called `title` with the value `My Website`.
-
-To evaluate the value of a variable, the `eval` instruction is used:
-
-```
-{{ eval title }}
-```
-
-The variable may be either defined in the same file as the evaluation is happening,
-or in a file which includes that file.
-
-If the variable cannot be found, a warning will be emitted during compilation, and the expression will appear as it is
-in the compiled resource.
-
-> The value of a variable is evaluated as an *expression*. See the next section for more details.
-
-It's possible to write more advanced expressions with variables as in the following example:
-
-```
-< div class="header {{ eval pageName == "Home" ? "highlight" : "" }}">Home</div>
-```
-
-##### Global context
-
-For convenience, a global context can be defined which can define constants that will be available in all processed
-sources.
-
-Simply create a file at `source/processed/_global_context` and write as many `define` instructions as you wish to define
-the global constants you might need.
-
-This is useful, for example, to define a `baseURL` for a website, which can then be used to create absolute links:
-
-```
-{{ define baseURL "/my-website/root/" }}
-```  
-
-Then, in any file, you can get an absolute URL to some file like this:
-
-```html
-<a href="{{ eval baseURL + `current/page.html` }}">This page link</a>
-```
-
-#### Expressions
-
-Expressions may appear in several different locations:
-
-* as an argument to the `eval` instruction.
-* as the value of a new variable defined by the `define` instruction.
-* as an argument to the `if` instruction.
-* as items of an iterable (array), used with the `for` instruction.
-
-For example, an expression may be evaluated with `eval`, with the result being displayed in the page:
-
-```
-{{ eval 2 + 2 * 5 }}
-```
-
-This should result in `12` being displayed.
-
-> Notice that expressions use a syntax very similar to C-like languages.
-
-The value of a new variable may also be determined by an expression:
-
-```
-{{ define n 10 + 10 * (2 + 4) }}
-```
-
-This results in the variable `n` assuming the value `70`.
-
-When an expression is used as an argument to the `if` instruction, it must evaluate to a boolean value (`true` or `false`).
-
-For example, the following is valid (given variable `n` is defined):
-
-```
-{{ if n > 50 }}N is large{{ end }}
-```
-
-Finally, it's possible to use expressions within arrays declared with the `for` instruction:
-
-```
-{{ for x [1 + 1, 2 + 2] }}
-X is {{ eval x }}
-{{ end }}
-```
-
-#### Conditional content
-
-The `if` instruction allows processed files to include content conditionally.
-
-Its argument is a single expression that is expected to evaluate to a boolean value.
-
-> Expressions that evaluate to any non-boolean value emit a warning and evaluate to `false`.
-
-For example:
-
-```
-{{ if title == "Home" }}
-<h1>Welcome Home!</h1>
-{{ end }}
-```
-
-In this example, the content `<h1>Welcome Home!</h1>` will only be displayed if the `title` variable has the
-value `"Home"`, otherwise, nothing would be displayed.
-
-#### Repeated content (for loops)
-
-The `for` instruction has the following arguments:
-
-* `item`       - a variable name to associate with each item of `iterable`.
-* `(sub-instructions)` - optional sub-instructions to modify how iteration is performed.
-* `iterable`   - an iterable object. 
-
-Two kinds of objects are iterable:
-
-* array expressions (e.g. `[1 2 3]`, `["Home", "About"]`).
-* file references to directories.
-
-Sub-instructions are optional and may take one of the following forms:
-
-* `sort`           - sorts the iterable.
-* `sortBy <field>` - sorts files by the given field (must be defined within each file).
-* `limit <n>`      - limit the number of items to iterate over.
-* `reverse`        - iterate in reverse order
-
-When multiple sub-instructions are provided, they are applied in the order they are declared, one at a time.
-
-Example iterating over an array:
-
-```
-{{ for title ["Home", "About", "FAQ"] }}
-<div>{{ eval title }}</div>
-{{ end for }}
-```
-
-The above, after processing, should look like this:
-
-```html
-<div>Home</div>
-<div>About</div>
-<div>FAQ</div>
-```
-
-See the section on iterables for details on how to work with iterables.
-
-File references are discussed in the next section.
-
-### File references
-
-References to other files, both from processed files and from HTML files that link to css or images, for example,
-may be relative or absolute.
-
-Absolute references start with a `/` and are always resolved with relation to `source/`.
-
-Examples:
-
-* `/images/ico.png` ---> `source/images/ico.png` (no processing).
-* `/processed/template.html` ---> `source/processed/template.html` (file contents will be processed).
-
-Relative references are resolved relative to the file declaring the reference.
-
-For example, within the `source/processed/template.html` file:
-
-* `about/index.html` ---> `source/processed/about/index.html` (file contents will be processed).
-* `../images/ico.png` ---> `source/images/ico.png` (no processing).
-
-Notice that referring to parent directories with `../` only works up to the `source/` directory:
-
-* `../../images/ico.png` --> `source/images/ico.png` (no processing).
-
-#### Iterating over file references
-
-File references pointing to a directory can be used with the `for` instruction as iterables over each file
-inside the directory.
-
-For example, to create a HTML menu containing links to each file under the `source/processed/posts/` directory:
-
-```
-{{ for post /processed/posts }}
-    <div>
-        <a href="/processed/posts/{{ eval post.name }}">
-        {{ eval post.date }} - {{ eval post.description }}
-        </a>
-    </div>
-{{ end }}
-```
-
-### Working with iterables
-
-Iterables are object that can be iterated over with the `for` instruction.
-
-As we've seen before, only arrays and file references to directories can be iterable.
-
-Examples:
-
-```
-<tr>
-{{ define columns ["ABC", "GHI", "DEF"] }}
-{{ for col (sort reverse) columns }}
-<th>{{ eval col }}</th>
-{{ end }}
-</tr>
-```
-
-Results in:
-
-```html
-<tr>
-<th>GHI</th>
-<th>DEF</th>
-<th>ABC</th>
-</tr>
-```
-
-Given a directory `source/processed/posts/` containing 10 files called `p1.md`, `p2.md`, and so on, each of which
-defining the `date` and `title` variables as in this example:
-
-```md
-{{ define date "2014-01-01 23:59:59" }}
-{{ define title "Example post" }}
-```
-
-We could display the 5 most recent posts' titles using the following snippet:
-
-```
-{{ for post (sortBy date reverse limit 5) "/processed/posts" }}
-  <div>{{ eval post.title }}</div>
-{{ end }}
-```

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		return
 	}
 
-	err = mg.WriteTo(filepath.Join(rootDir, TargetDir), webFiles)
+	err = mag.WriteTo(filepath.Join(rootDir, TargetDir), webFiles)
 	if err != nil {
 		log.Printf("ERROR: %s", err)
 		panic(err)

--- a/mg/component.go
+++ b/mg/component.go
@@ -16,7 +16,7 @@ type componentContext struct {
 
 type writeContext struct {
 	files          WebFilesMap
-	inclusionChain []InclusionChainItem
+	inclusionChain []ContextStackItem
 }
 
 type Component struct {
@@ -106,7 +106,7 @@ func NewComponentInstruction(arg string, location Location, original string,
 	}
 }
 
-func (c *Component) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
+func (c *Component) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
 	path := c.Resolver.Resolve(c.Path, c.Origin)
 	//fmt.Printf("Including %s from %v : %s\n", c.Path, c.Origin, path)
 	componentFile, ok := files.WebFiles[path]
@@ -117,7 +117,7 @@ func (c *Component) Write(writer io.Writer, files WebFilesMap, inclusionChain []
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		inclusionChain = append(inclusionChain, InclusionChainItem{Location: &c.Origin, scope: c})
+		inclusionChain = append(inclusionChain, ContextStackItem{Location: &c.Origin, scope: c})
 		//ss:= inclusionChainToString(inclusionChain)
 		//fmt.Printf("Chain: %s", ss)
 		for _, f := range inclusionChain {

--- a/mg/component.go
+++ b/mg/component.go
@@ -22,7 +22,6 @@ type writeContext struct {
 type Component struct {
 	Location Location
 	context  componentContext
-	parent   Scope
 	Text     string
 	Path     string
 	Origin   Location
@@ -30,7 +29,6 @@ type Component struct {
 }
 
 var _ Context = (*componentContext)(nil)
-var _ Scope = (*Component)(nil)
 var _ Content = (*Component)(nil)
 var _ ContentContainer = (*Component)(nil)
 
@@ -106,7 +104,7 @@ func NewComponentInstruction(arg string, location Location, original string,
 	}
 }
 
-func (c *Component) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
+func (c *Component) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	path := c.Resolver.Resolve(c.Path, c.Origin)
 	//fmt.Printf("Including %s from %v : %s\n", c.Path, c.Origin, path)
 	componentFile, ok := files.WebFiles[path]

--- a/mg/component.go
+++ b/mg/component.go
@@ -1,137 +1,60 @@
 package mg
 
 import (
-	"fmt"
 	"io"
 	"log"
-	"strings"
 )
 
-type componentContext struct {
-	contents       []Content
-	cachedContents *string
-	Map            map[string]interface{}
-	writeContext   *writeContext
-}
-
-type writeContext struct {
-	files          WebFilesMap
-	inclusionChain []ContextStackItem
-}
-
 type Component struct {
-	Location Location
-	context  componentContext
-	Text     string
 	Path     string
-	Origin   Location
+	Location *Location
+	Text     string
 	Resolver FileResolver
+	contents []Content
 }
 
-var _ Context = (*componentContext)(nil)
 var _ Content = (*Component)(nil)
 var _ ContentContainer = (*Component)(nil)
 
 func (c *Component) AppendContent(content Content) {
-	c.context.contents = append(c.context.contents, content)
+	c.contents = append(c.contents, content)
 }
 
 func (c *Component) GetContents() []Content {
-	return c.context.contents
-}
-
-func (c *Component) Context() Context {
-	return &c.context
-}
-
-func (c *Component) Parent() Scope {
-	return c.parent
-}
-
-func (c *componentContext) Get(name string) (interface{}, bool) {
-	if name == "__contents__" {
-		return c.content()
-	}
-	v, ok := c.Map[name]
-	return v, ok
-}
-
-func (c *componentContext) Set(name string, value interface{}) {
-	c.Map[name] = value
-}
-
-func (c *componentContext) IsEmpty() bool {
-	return len(c.Map) == 0 && len(c.contents) == 0
-}
-
-func (c *componentContext) mixInto(other Context) {
-	// components do not mix into their surrounding scope
-}
-
-func (c *componentContext) content() (string, bool) {
-	if c.cachedContents != nil {
-		return *c.cachedContents, true
-	}
-
-	if wctx := c.writeContext; wctx != nil {
-		// resolve contents and cache it
-		var writer strings.Builder
-		for _, content := range c.contents {
-			err := content.Write(&writer, wctx.files, wctx.inclusionChain)
-			if err != nil {
-				return "", false
-			}
-		}
-		contents := writer.String()
-		c.cachedContents = &contents
-		return contents, true
-	} else {
-		panic("Tried to write component before write context was set")
-	}
+	return c.contents
 }
 
 func NewComponentInstruction(arg string, location *Location, original string, resolver FileResolver) Content {
-	compContext := componentContext{Map: make(map[string]interface{}, 2)}
 	return &Component{
 		Path:     arg,
 		Location: location,
-		Resolver: resolver,
-		parent:   scope,
-		context:  compContext,
 		Text:     original,
-		Origin:   location,
+		Resolver: resolver,
 	}
 }
 
 func (c *Component) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
-	path := c.Resolver.Resolve(c.Path, c.Origin)
+	path := c.Resolver.Resolve(c.Path, c.Location)
 	//fmt.Printf("Including %s from %v : %s\n", c.Path, c.Origin, path)
 	componentFile, ok := files.WebFiles[path]
 	if !ok {
-		log.Printf("WARNING: (%s) refers to a non-existent Component: %s", c.Origin.String(), c.Path)
+		log.Printf("WARNING: (%s) refers to a non-existent Component: %s", c.Location, c.Path)
 		_, err := writer.Write([]byte(c.Text))
 		if err != nil {
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		inclusionChain = append(inclusionChain, ContextStackItem{Location: &c.Origin, scope: c})
-		//ss:= inclusionChainToString(inclusionChain)
-		//fmt.Printf("Chain: %s", ss)
-		for _, f := range inclusionChain {
-			if f.Location.Origin == path {
-				chain := inclusionChainToString(inclusionChain)
-				return &MagnanimousError{
-					Code: InclusionCycleError,
-					message: fmt.Sprintf(
-						"Cycle detected! Inclusion of %s at %s comes back into itself via %s",
-						c.Path, c.Origin.String(), chain),
-				}
-			}
+		stack = stack.Push(c.Location)
+		err := detectCycle(stack, path, c.Location)
+		if err != nil {
+			return err
 		}
-
-		c.context.writeContext = &writeContext{files: files, inclusionChain: inclusionChain}
-		runSideEffects(c, &files, inclusionChain)
-		err := writeContents(componentFile.Processed, writer, files, inclusionChain, true)
+		contents, err := body(c, files, stack)
+		if err != nil {
+			return err
+		}
+		stack.Top().Context.Set("__contents__", string(contents))
+		err = componentFile.Write(writer, files, stack)
 		if err != nil {
 			return err
 		}

--- a/mg/component.go
+++ b/mg/component.go
@@ -90,8 +90,7 @@ func (c *componentContext) content() (string, bool) {
 	}
 }
 
-func NewComponentInstruction(arg string, location Location, original string,
-	scope Scope, resolver FileResolver) Content {
+func NewComponentInstruction(arg string, location *Location, original string, resolver FileResolver) Content {
 	compContext := componentContext{Map: make(map[string]interface{}, 2)}
 	return &Component{
 		Path:     arg,

--- a/mg/component.go
+++ b/mg/component.go
@@ -44,7 +44,7 @@ func (c *Component) Write(writer io.Writer, files WebFilesMap, stack ContextStac
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		stack = stack.Push(c.Location)
+		stack = stack.Push(c.Location, false)
 		err := detectCycle(stack, c.Path, path, c.Location)
 		if err != nil {
 			return err
@@ -53,7 +53,7 @@ func (c *Component) Write(writer io.Writer, files WebFilesMap, stack ContextStac
 		if err != nil {
 			return err
 		}
-		stack.Top().Context.Set("__contents__", string(contents))
+		stack.Top().Set("__contents__", string(contents))
 		err = componentFile.Write(writer, files, stack)
 		if err != nil {
 			return err

--- a/mg/component.go
+++ b/mg/component.go
@@ -45,7 +45,7 @@ func (c *Component) Write(writer io.Writer, files WebFilesMap, stack ContextStac
 		}
 	} else {
 		stack = stack.Push(c.Location)
-		err := detectCycle(stack, path, c.Location)
+		err := detectCycle(stack, c.Path, path, c.Location)
 		if err != nil {
 			return err
 		}

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -1,0 +1,44 @@
+package mg
+
+type mapContext struct {
+	data map[string]interface{}
+}
+
+var _ Context = (*mapContext)(nil)
+
+func (c *mapContext) Get(name string) (interface{}, bool) {
+	v, ok := c.data[name]
+	return v, ok
+}
+
+func (c *mapContext) Set(name string, value interface{}) {
+	c.data[name] = value
+}
+
+func (c *mapContext) IsEmpty() bool {
+	return len(c.data) == 0
+}
+
+func (c *ContextStack) Push(location *Location) ContextStack {
+	item := ContextStackItem{Location: location, Context: &mapContext{}}
+	items := append(c.chain, item)
+	return ContextStack{items}
+}
+
+func (c *ContextStack) Top() *ContextStackItem {
+	if len(c.chain) == 0 {
+		return nil
+	}
+	return &c.chain[len(c.chain)-1]
+}
+
+func (c *ContextStack) GetContextAt(index int) Context {
+	if len(c.chain) > 0 {
+		return c.chain[0].Context
+	}
+	return nil
+}
+
+func (c *ContextStack) Size() int {
+	return len(c.chain)
+}

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -1,31 +1,39 @@
 package mg
 
+// NewContextStack creates a stack with a single context in it.
 func NewContextStack(context Context) ContextStack {
-	items := make([]ContextStackItem, 1)
-	items[0] = ContextStackItem{Context: context}
-	return ContextStack{items}
+	ctxs := make([]Context, 1, 10)
+	ctxs[0] = context
+	return ContextStack{contexts: ctxs}
 }
 
 // Push a new item on the scope stack.
-// Only provide a location if this scope is including another file.
-func (c *ContextStack) Push(location *Location) ContextStack {
-	item := ContextStackItem{Location: location, Context: CreateContext()}
-	items := append(c.chain, item)
-	return ContextStack{items}
-}
-
-func (c *ContextStack) Top() *ContextStackItem {
-	if len(c.chain) == 0 {
-		return nil
+//
+// Only provide a location if this scope is including another file, otherwise provide nil.
+// If createScope is true, push a new [Context] onto the stack, otherwise just update the inclusion location stack.
+func (c *ContextStack) Push(location *Location, createScope bool) ContextStack {
+	if location != nil {
+		c.locations = append(c.locations, *location)
 	}
-	return &c.chain[len(c.chain)-1]
+	if createScope {
+		scopes := append(c.contexts, NewContext())
+		return ContextStack{locations: c.locations, contexts: scopes}
+	}
+	return *c
 }
 
+// Top gives the top element on the stack.
+func (c *ContextStack) Top() Context {
+	return c.contexts[len(c.contexts)-1]
+}
+
+// GetContextAt returns the [Context] at the given index on the stack (0 is the top of the stack).
 func (c *ContextStack) GetContextAt(index int) Context {
-	l := len(c.chain)
-	return c.chain[l-1-index].Context
+	l := len(c.contexts)
+	return c.contexts[l-1-index]
 }
 
+// Size of the stack.
 func (c *ContextStack) Size() int {
-	return len(c.chain)
+	return len(c.contexts)
 }

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -1,24 +1,5 @@
 package mg
 
-type mapContext struct {
-	data map[string]interface{}
-}
-
-var _ Context = (*mapContext)(nil)
-
-func (c *mapContext) Get(name string) (interface{}, bool) {
-	v, ok := c.data[name]
-	return v, ok
-}
-
-func (c *mapContext) Set(name string, value interface{}) {
-	c.data[name] = value
-}
-
-func (c *mapContext) IsEmpty() bool {
-	return len(c.data) == 0
-}
-
 func NewContextStack(context Context) ContextStack {
 	items := make([]ContextStackItem, 1)
 	items[0] = ContextStackItem{Context: context}
@@ -26,7 +7,7 @@ func NewContextStack(context Context) ContextStack {
 }
 
 func (c *ContextStack) Push(location *Location) ContextStack {
-	item := ContextStackItem{Location: location, Context: &mapContext{}}
+	item := ContextStackItem{Location: location, Context: &MapContext{}}
 	items := append(c.chain, item)
 	return ContextStack{items}
 }

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -19,6 +19,12 @@ func (c *mapContext) IsEmpty() bool {
 	return len(c.data) == 0
 }
 
+func NewContextStack(context Context) ContextStack {
+	items := make([]ContextStackItem, 1)
+	items[0] = ContextStackItem{Context: context}
+	return ContextStack{items}
+}
+
 func (c *ContextStack) Push(location *Location) ContextStack {
 	item := ContextStackItem{Location: location, Context: &mapContext{}}
 	items := append(c.chain, item)

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -6,8 +6,10 @@ func NewContextStack(context Context) ContextStack {
 	return ContextStack{items}
 }
 
+// Push a new item on the scope stack.
+// Only provide a location if this scope is including another file.
 func (c *ContextStack) Push(location *Location) ContextStack {
-	item := ContextStackItem{Location: location, Context: &MapContext{}}
+	item := ContextStackItem{Location: location, Context: CreateContext()}
 	items := append(c.chain, item)
 	return ContextStack{items}
 }

--- a/mg/context_stack.go
+++ b/mg/context_stack.go
@@ -22,10 +22,8 @@ func (c *ContextStack) Top() *ContextStackItem {
 }
 
 func (c *ContextStack) GetContextAt(index int) Context {
-	if len(c.chain) > 0 {
-		return c.chain[0].Context
-	}
-	return nil
+	l := len(c.chain)
+	return c.chain[l-1-index].Context
 }
 
 func (c *ContextStack) Size() int {

--- a/mg/copy.go
+++ b/mg/copy.go
@@ -31,7 +31,7 @@ type copiedContent struct {
 	file string
 }
 
-func (c *copiedContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
+func (c *copiedContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
 	f, err := os.Open(c.file)
 	if err != nil {
 		return &MagnanimousError{Code: IOError, message: err.Error()}

--- a/mg/copy.go
+++ b/mg/copy.go
@@ -31,7 +31,7 @@ type copiedContent struct {
 	file string
 }
 
-func (c *copiedContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
+func (c *copiedContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	f, err := os.Open(c.file)
 	if err != nil {
 		return &MagnanimousError{Code: IOError, message: err.Error()}

--- a/mg/expression.go
+++ b/mg/expression.go
@@ -57,7 +57,15 @@ func (e *ExpressionContent) Write(writer io.Writer, files WebFilesMap, stack Con
 		webFiles: files,
 	})
 	if err == nil {
-		_, err = writer.Write([]byte(fmt.Sprintf("%v", r)))
+		// an expression can evaluate to a content container, such as a slot
+		if c, ok := r.(ContentContainer); ok {
+			err = writeContents(c, writer, files, stack)
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err = writer.Write([]byte(fmt.Sprintf("%v", r)))
+		}
 	} else {
 		log.Printf("WARNING: (%s) eval failure: %s", e.Location.String(), err.Error())
 		_, err = writer.Write([]byte(fmt.Sprintf("{{%s}}", e.Text)))

--- a/mg/expression.go
+++ b/mg/expression.go
@@ -85,7 +85,11 @@ var _ Content = (*DefineContent)(nil)
 func (d *DefineContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	// DefineContent does not write anything!
 	if v, ok := d.Eval(files, stack); ok {
-		stack.Top().Context.Set(d.Name, v)
+		if v == nil {
+			stack.Top().Remove(d.Name)
+		} else {
+			stack.Top().Set(d.Name, v)
+		}
 	}
 	return nil
 }

--- a/mg/expression/parser.go
+++ b/mg/expression/parser.go
@@ -10,18 +10,24 @@ import (
 	"strings"
 )
 
+// Expression is a parsed Magnanimous expression.
+//
+// It can be evaluated with the [EvalExpr] function.
 type Expression struct {
 	expr ast.Expr
 }
 
+// Context contains the bindings available for an expression.
 type Context interface {
 	Get(name string) (interface{}, bool)
 }
 
+// MapContext is a simple implementation of [Context].
 type MapContext struct {
 	Map map[string]interface{}
 }
 
+// Get the value of a binding from the context.
 func (m *MapContext) Get(name string) (interface{}, bool) {
 	if m == nil {
 		return nil, false
@@ -30,6 +36,7 @@ func (m *MapContext) Get(name string) (interface{}, bool) {
 	return v, ok
 }
 
+// ParseExpr parses the given string as a Magnanimous expression.
 func ParseExpr(expr string) (Expression, error) {
 	e, err := parser.ParseExpr(expr)
 	if err != nil {
@@ -38,6 +45,8 @@ func ParseExpr(expr string) (Expression, error) {
 	return Expression{expr: e}, nil
 }
 
+// Eval evaluates the given string as a Magnanimous expression, making the context bindings
+// available to the expression.
 func Eval(expr string, context Context) (interface{}, error) {
 	e, err := ParseExpr(expr)
 	if err != nil {
@@ -46,6 +55,8 @@ func Eval(expr string, context Context) (interface{}, error) {
 	return EvalExpr(e, context)
 }
 
+// EvalExpr evaluates the given Magnanimous expression, making the context bindings
+//// available to the expression.
 func EvalExpr(e Expression, context Context) (interface{}, error) {
 	return eval(e.expr, context)
 }
@@ -184,6 +195,7 @@ func resolveAccessField(expr *ast.SelectorExpr, ctx Context) (interface{}, error
 	return nil, errors.New(fmt.Sprintf("cannot access properties of object: %v", rcv))
 }
 
+// ToContext attempts to convert a variable to a [Context].
 func ToContext(ctx interface{}) (Context, bool) {
 	if v, ok := ctx.(Context); ok {
 		return v, true

--- a/mg/files.go
+++ b/mg/files.go
@@ -57,7 +57,7 @@ func getFilesAt(root string, exclusions ...string) ([]string, error) {
 	return files, err
 }
 
-func (r *DefaultFileResolver) FilesIn(dir string, from Location) (dirPath string, webFiles []WebFile, e error) {
+func (r *DefaultFileResolver) FilesIn(dir string, from *Location) (dirPath string, webFiles []WebFile, e error) {
 	dirPath = Resolve(dir, r.BasePath, from)
 	for path, wf := range r.Files.WebFiles {
 		if !wf.NonWritable && filepath.Dir(path) == dirPath {
@@ -67,11 +67,11 @@ func (r *DefaultFileResolver) FilesIn(dir string, from Location) (dirPath string
 	return
 }
 
-func (r *DefaultFileResolver) Resolve(path string, from Location) string {
+func (r *DefaultFileResolver) Resolve(path string, from *Location) string {
 	return Resolve(path, r.BasePath, from)
 }
 
-func Resolve(path, basePath string, from Location) string {
+func Resolve(path, basePath string, from *Location) string {
 	if strings.HasPrefix(path, "/") {
 		// absolute path
 		return filepath.Join(basePath, path)

--- a/mg/for.go
+++ b/mg/for.go
@@ -92,17 +92,17 @@ func (f *ForLoop) AppendContent(content Content) {
 }
 
 func (f *ForLoop) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
-	stack = stack.Push(nil)
+	stack = stack.Push(nil, true)
 	err := f.iter.forEach(files, stack, magParams{
 		webFiles: files,
 		stack:    stack,
 	}, func(file *webFileWithContext) error {
 		// use the file's context as the value of the bound variable
-		stack.Top().Context.Set(f.Variable, file.context)
+		stack.Top().Set(f.Variable, file.context)
 		return writeContents(f, writer, files, stack)
 	}, func(item interface{}) error {
 		// use whatever was evaluated from the array as the bound variable
-		stack.Top().Context.Set(f.Variable, item)
+		stack.Top().Set(f.Variable, item)
 		return writeContents(f, writer, files, stack)
 	})
 

--- a/mg/for.go
+++ b/mg/for.go
@@ -185,9 +185,9 @@ func (e *directoryIterable) filesWithContext(files WebFilesMap, stack ContextSta
 	}
 
 	webFilesCtx := make([]webFileWithContext, len(webFiles))
-	for i, webFile := range webFiles {
-		ctx := webFile.Processed.ResolveContext(files, stack)
-		webFilesCtx[i] = webFileWithContext{file: &webFile, context: ctx}
+	for i, wf := range webFiles {
+		ctx := wf.Processed.ResolveContext(files, stack)
+		webFilesCtx[i] = webFileWithContext{file: &wf, context: ctx}
 	}
 	return webFilesCtx, nil
 }

--- a/mg/for.go
+++ b/mg/for.go
@@ -14,10 +14,8 @@ type ForLoop struct {
 	Variable string
 	iter     iterable
 	Text     string
-	Location Location
+	Location *Location
 	contents []Content
-	context  map[string]interface{}
-	parent   Scope
 }
 
 type forLoopSubInstruction struct {
@@ -37,30 +35,34 @@ type limitSubInstruction struct {
 type reverseSubInstruction struct {
 }
 
-type fileConsumer func(file *WebFile) error
+type webFileWithContext struct {
+	file    *WebFile
+	context Context
+}
+
+type fileConsumer func(file *webFileWithContext) error
 
 type itemConsumer func(interface{}) error
 
 type iterable interface {
-	forEach(files WebFilesMap, inclusionChain []InclusionChainItem,
+	forEach(files WebFilesMap, stack ContextStack,
 		parameters magParams, fc fileConsumer, ic itemConsumer) error
 }
 
 type arrayIterable struct {
 	array           *expression.Expression
-	location        Location
+	location        *Location
 	subInstructions []forLoopSubInstruction
 }
 
 type directoryIterable struct {
 	path            string
 	resolver        FileResolver
-	location        Location
+	location        *Location
 	subInstructions []forLoopSubInstruction
 }
 
-func NewForInstruction(arg string, location Location, original string,
-	scope Scope, resolver FileResolver) Content {
+func NewForInstruction(arg string, location *Location, original string, resolver FileResolver) Content {
 	parts := strings.SplitN(arg, " ", 2)
 	switch len(parts) {
 	case 0:
@@ -75,12 +77,10 @@ func NewForInstruction(arg string, location Location, original string,
 			location.String(), arg, err.Error())
 		return unevaluatedExpression(original)
 	}
-	return &ForLoop{Variable: parts[0], iter: iter, parent: scope,
-		Text: original, Location: location, context: make(map[string]interface{}, 2)}
+	return &ForLoop{Variable: parts[0], iter: iter, Text: original, Location: location}
 }
 
 var _ Content = (*ForLoop)(nil)
-var _ Scope = (*ForLoop)(nil)
 var _ ContentContainer = (*ForLoop)(nil)
 
 func (f *ForLoop) GetContents() []Content {
@@ -91,28 +91,21 @@ func (f *ForLoop) AppendContent(content Content) {
 	f.contents = append(f.contents, content)
 }
 
-func (f *ForLoop) Context() Context {
-	return &MapContext{Map: f.context}
-}
-
-func (f *ForLoop) Parent() Scope {
-	return f.parent
-}
-
-func (f *ForLoop) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
-	err := f.iter.forEach(files, inclusionChain, magParams{
-		webFiles:       &files,
-		inclusionChain: inclusionChain,
-		scope:          f,
-	}, func(webFile *WebFile) error {
+func (f *ForLoop) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
+	stack = stack.Push(f.Location)
+	err := f.iter.forEach(files, stack, magParams{
+		webFiles: files,
+		stack:    stack,
+	}, func(file *webFileWithContext) error {
 		// use the file's context as the value of the bound variable
-		f.context[f.Variable] = webFile.Processed.Context()
-		return writeContents(f, writer, files, inclusionChain, false)
+		stack.Top().Context.Set(f.Variable, file.context)
+		return writeContents(f, writer, files, stack)
 	}, func(item interface{}) error {
 		// use whatever was evaluated from the array as the bound variable
-		f.Context().Set(f.Variable, item)
-		return writeContents(f, writer, files, inclusionChain, false)
+		stack.Top().Context.Set(f.Variable, item)
+		return writeContents(f, writer, files, stack)
 	})
+
 	if err != nil {
 		return &MagnanimousError{Code: IOError, message: err.Error()}
 	}
@@ -123,7 +116,7 @@ func (f *ForLoop) String() string {
 	return fmt.Sprintf("ForLoop{%s}", f.Text)
 }
 
-func asIterable(arg string, location Location, resolver FileResolver) (iterable, error) {
+func asIterable(arg string, location *Location, resolver FileResolver) (iterable, error) {
 	var forArg string
 	var subInstructions []forLoopSubInstruction
 	if strings.HasPrefix(arg, "(") {
@@ -139,7 +132,7 @@ func asIterable(arg string, location Location, resolver FileResolver) (iterable,
 }
 
 func iterableFrom(forArg string, subInstructions []forLoopSubInstruction,
-	location Location, resolver FileResolver) (iterable, error) {
+	location *Location, resolver FileResolver) (iterable, error) {
 
 	if strings.HasPrefix(forArg, "[") && strings.HasSuffix(forArg, "]") {
 		expr, err := expression.ParseExpr(fmt.Sprintf("[]interface{}{%s}", forArg[1:len(forArg)-1]))
@@ -151,7 +144,7 @@ func iterableFrom(forArg string, subInstructions []forLoopSubInstruction,
 	return &directoryIterable{path: forArg, location: location, resolver: resolver, subInstructions: subInstructions}, nil
 }
 
-func (e *arrayIterable) forEach(files WebFilesMap, inclusionChain []InclusionChainItem,
+func (e *arrayIterable) forEach(files WebFilesMap, stack ContextStack,
 	parameters magParams, fc fileConsumer, ic itemConsumer) error {
 	v, err := expression.EvalExpr(*e.array, parameters)
 	if err != nil {
@@ -185,9 +178,23 @@ func (e *arrayIterable) forEach(files WebFilesMap, inclusionChain []InclusionCha
 	return nil
 }
 
-func (e *directoryIterable) forEach(files WebFilesMap, inclusionChain []InclusionChainItem,
-	parameters magParams, fc fileConsumer, ic itemConsumer) error {
+func (e *directoryIterable) filesWithContext(files WebFilesMap, stack ContextStack) ([]webFileWithContext, error) {
 	_, webFiles, err := e.resolver.FilesIn(e.path, e.location)
+	if err != nil {
+		return nil, err
+	}
+
+	webFilesCtx := make([]webFileWithContext, len(webFiles))
+	for i, webFile := range webFiles {
+		ctx := webFile.Processed.ResolveContext(files, stack)
+		webFilesCtx[i] = webFileWithContext{file: &webFile, context: ctx}
+	}
+	return webFilesCtx, nil
+}
+
+func (e *directoryIterable) forEach(files WebFilesMap, stack ContextStack,
+	parameters magParams, fc fileConsumer, ic itemConsumer) error {
+	webFilesCtx, err := e.filesWithContext(files, stack)
 	if err != nil {
 		return err
 	}
@@ -196,35 +203,31 @@ func (e *directoryIterable) forEach(files WebFilesMap, inclusionChain []Inclusio
 	sortByName := len(e.subInstructions) == 0 || e.subInstructions[0].sortBy == nil
 
 	if sortByName {
-		sort.Slice(webFiles, func(i, j int) bool {
-			return webFiles[i].Name < webFiles[j].Name
+		sort.Slice(webFilesCtx, func(i, j int) bool {
+			return webFilesCtx[i].file.Name < webFilesCtx[j].file.Name
 		})
-	}
-
-	for _, item := range webFiles {
-		item.runSideEffects(&files, inclusionChain)
 	}
 
 	for _, subInstruction := range e.subInstructions {
 		if subInstruction.sortBy != nil {
 			sortField := subInstruction.sortBy.field
-			sortFiles(webFiles, sortField)
+			sortFiles(webFilesCtx, sortField)
 		}
 
 		if subInstruction.reverse != nil {
-			reverseFiles(webFiles)
+			reverseFiles(webFilesCtx)
 		}
 
 		if subInstruction.limit != nil {
-			limit := len(webFiles)
+			limit := len(webFilesCtx)
 			if subInstruction.limit.max < limit {
 				limit = subInstruction.limit.max
 			}
-			webFiles = webFiles[0:limit]
+			webFilesCtx = webFilesCtx[:limit]
 		}
 	}
 
-	for _, item := range webFiles {
+	for _, item := range webFilesCtx {
 		err := fc(&item)
 		if err != nil {
 			return err
@@ -291,18 +294,18 @@ func sortArray(array []interface{}, instruction *sortBySubInstruction) {
 	})
 }
 
-func sortFiles(webFiles []WebFile, sortField string) {
+func sortFiles(webFiles []webFileWithContext, sortField string) {
 	sort.Slice(webFiles, func(i, j int) bool {
-		iv, ok := webFiles[i].Processed.Context().Get(sortField)
+		iv, ok := webFiles[i].context.Get(sortField)
 		if !ok {
 			log.Printf("WARN: cannot sortBy %s - file %s does not define such property",
-				sortField, webFiles[i].Name)
+				sortField, webFiles[i].file.Name)
 			return true
 		}
-		jv, ok := webFiles[j].Processed.Context().Get(sortField)
+		jv, ok := webFiles[j].context.Get(sortField)
 		if !ok {
 			log.Printf("WARN: cannot sortBy %s - file %s does not define such property",
-				sortField, webFiles[j].Name)
+				sortField, webFiles[j].file.Name)
 			return true
 		}
 		res, err := expression.Less(iv, jv)
@@ -314,7 +317,7 @@ func sortFiles(webFiles []WebFile, sortField string) {
 	})
 }
 
-func reverseFiles(webFiles []WebFile) {
+func reverseFiles(webFiles []webFileWithContext) {
 	for i := len(webFiles)/2 - 1; i >= 0; i-- {
 		opp := len(webFiles) - 1 - i
 		webFiles[i], webFiles[opp] = webFiles[opp], webFiles[i]

--- a/mg/for.go
+++ b/mg/for.go
@@ -92,7 +92,7 @@ func (f *ForLoop) AppendContent(content Content) {
 }
 
 func (f *ForLoop) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
-	stack = stack.Push(f.Location)
+	stack = stack.Push(nil)
 	err := f.iter.forEach(files, stack, magParams{
 		webFiles: files,
 		stack:    stack,

--- a/mg/for.go
+++ b/mg/for.go
@@ -187,7 +187,9 @@ func (e *directoryIterable) filesWithContext(files WebFilesMap, stack ContextSta
 	webFilesCtx := make([]webFileWithContext, len(webFiles))
 	for i, wf := range webFiles {
 		ctx := wf.Processed.ResolveContext(files, stack)
-		webFilesCtx[i] = webFileWithContext{file: &wf, context: ctx}
+		// we must create a new ref here otherwise the file ref will point to the loop ref, which changes!
+		refToFile := wf
+		webFilesCtx[i] = webFileWithContext{file: &refToFile, context: ctx}
 	}
 	return webFilesCtx, nil
 }

--- a/mg/if.go
+++ b/mg/if.go
@@ -50,7 +50,7 @@ func (ic *IfContent) Write(writer io.Writer, files WebFilesMap, stack ContextSta
 
 	switch res {
 	case true:
-		stack = stack.Push(ic.Location)
+		stack = stack.Push(nil)
 		err = writeContents(ic, writer, files, stack)
 		if err != nil {
 			return err

--- a/mg/if.go
+++ b/mg/if.go
@@ -41,7 +41,7 @@ func (ic *IfContent) AppendContent(content Content) {
 
 func (ic *IfContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	res, err := expression.EvalExpr(*ic.condition, magParams{
-		webFiles: &files,
+		webFiles: files,
 		stack:    stack,
 	})
 	if err != nil {

--- a/mg/if.go
+++ b/mg/if.go
@@ -50,7 +50,7 @@ func (ic *IfContent) Write(writer io.Writer, files WebFilesMap, stack ContextSta
 
 	switch res {
 	case true:
-		stack = stack.Push(nil)
+		stack = stack.Push(nil, true)
 		err = writeContents(ic, writer, files, stack)
 		if err != nil {
 			return err

--- a/mg/include.go
+++ b/mg/include.go
@@ -33,9 +33,7 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 		}
 	} else {
 		stack = stack.Push(inc.Origin)
-		//ss:= inclusionChainToString(inclusionChain)
-		//fmt.Printf("Chain: %s", ss)
-		err := inc.detectCycle(stack, path)
+		err := detectCycle(stack, path, inc.Origin)
 		if err != nil {
 			return err
 		}
@@ -47,7 +45,7 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 	return nil
 }
 
-func (inc *IncludeInstruction) detectCycle(stack ContextStack, path string) error {
+func detectCycle(stack ContextStack, path string, location *Location) error {
 	for _, f := range stack.chain {
 		if f.Location.Origin == path {
 			chain := inclusionChainToString(stack.chain)
@@ -55,7 +53,7 @@ func (inc *IncludeInstruction) detectCycle(stack ContextStack, path string) erro
 				Code: InclusionCycleError,
 				message: fmt.Sprintf(
 					"Cycle detected! Inclusion of %s at %s comes back into itself via %s",
-					inc.Path, inc.Origin.String(), chain),
+					path, location.String(), chain),
 			}
 		}
 	}

--- a/mg/include.go
+++ b/mg/include.go
@@ -22,7 +22,7 @@ func (inc *IncludeInstruction) String() string {
 }
 
 func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
-	path := inc.Resolver.Resolve(inc.Path, *inc.Origin)
+	path := inc.Resolver.Resolve(inc.Path, inc.Origin)
 	//fmt.Printf("Including %s from %v : %s\n", inc.Path, inc.Origin, path)
 	webFile, ok := files.WebFiles[path]
 	if !ok {

--- a/mg/include.go
+++ b/mg/include.go
@@ -9,11 +9,11 @@ import (
 type IncludeInstruction struct {
 	Text     string
 	Path     string
-	Origin   Location
+	Origin   *Location
 	Resolver FileResolver
 }
 
-func NewIncludeInstruction(arg string, location Location, original string, resolver FileResolver) *IncludeInstruction {
+func NewIncludeInstruction(arg string, location *Location, original string, resolver FileResolver) *IncludeInstruction {
 	return &IncludeInstruction{Text: original, Path: arg, Origin: location, Resolver: resolver}
 }
 
@@ -21,8 +21,8 @@ func (inc *IncludeInstruction) String() string {
 	return fmt.Sprintf("IncludeInstruction{%s, %v, %v}", inc.Path, inc.Origin, inc.Resolver)
 }
 
-func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
-	path := inc.Resolver.Resolve(inc.Path, inc.Origin)
+func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
+	path := inc.Resolver.Resolve(inc.Path, *inc.Origin)
 	//fmt.Printf("Including %s from %v : %s\n", inc.Path, inc.Origin, path)
 	webFile, ok := files.WebFiles[path]
 	if !ok {
@@ -32,23 +32,31 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, inclus
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		inclusionChain = append(inclusionChain, InclusionChainItem{Location: &inc.Origin})
+		stack = stack.Push(inc.Origin)
 		//ss:= inclusionChainToString(inclusionChain)
 		//fmt.Printf("Chain: %s", ss)
-		for _, f := range inclusionChain {
-			if f.Location.Origin == path {
-				chain := inclusionChainToString(inclusionChain)
-				return &MagnanimousError{
-					Code: InclusionCycleError,
-					message: fmt.Sprintf(
-						"Cycle detected! Inclusion of %s at %s comes back into itself via %s",
-						inc.Path, inc.Origin.String(), chain),
-				}
-			}
-		}
-		err := webFile.Write(writer, files, inclusionChain)
+		err := inc.detectCycle(stack, path)
 		if err != nil {
 			return err
+		}
+		err = webFile.Write(writer, files, stack)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inc *IncludeInstruction) detectCycle(stack ContextStack, path string) error {
+	for _, f := range stack.chain {
+		if f.Location.Origin == path {
+			chain := inclusionChainToString(stack.chain)
+			return &MagnanimousError{
+				Code: InclusionCycleError,
+				message: fmt.Sprintf(
+					"Cycle detected! Inclusion of %s at %s comes back into itself via %s",
+					inc.Path, inc.Origin.String(), chain),
+			}
 		}
 	}
 	return nil

--- a/mg/include.go
+++ b/mg/include.go
@@ -33,7 +33,7 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 		}
 	} else {
 		stack = stack.Push(inc.Origin)
-		err := detectCycle(stack, path, inc.Origin)
+		err := detectCycle(stack, inc.Path, path, inc.Origin)
 		if err != nil {
 			return err
 		}
@@ -45,15 +45,15 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 	return nil
 }
 
-func detectCycle(stack ContextStack, path string, location *Location) error {
+func detectCycle(stack ContextStack, includedPath, absPath string, location *Location) error {
 	for _, f := range stack.chain {
-		if f.Location.Origin == path {
+		if f.Location != nil && f.Location.Origin == absPath {
 			chain := inclusionChainToString(stack.chain)
 			return &MagnanimousError{
 				Code: InclusionCycleError,
 				message: fmt.Sprintf(
 					"Cycle detected! Inclusion of %s at %s comes back into itself via %s",
-					path, location.String(), chain),
+					includedPath, location.String(), chain),
 			}
 		}
 	}

--- a/mg/include.go
+++ b/mg/include.go
@@ -32,7 +32,7 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		stack = stack.Push(inc.Origin)
+		stack = stack.Push(inc.Origin, false)
 		err := detectCycle(stack, inc.Path, path, inc.Origin)
 		if err != nil {
 			return err
@@ -46,9 +46,9 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, stack 
 }
 
 func detectCycle(stack ContextStack, includedPath, absPath string, location *Location) error {
-	for _, f := range stack.chain {
-		if f.Location != nil && f.Location.Origin == absPath {
-			chain := inclusionChainToString(stack.chain)
+	for _, loc := range stack.locations {
+		if loc.Origin == absPath {
+			chain := inclusionChainToString(stack.locations)
 			return &MagnanimousError{
 				Code: InclusionCycleError,
 				message: fmt.Sprintf(

--- a/mg/include.go
+++ b/mg/include.go
@@ -10,12 +10,11 @@ type IncludeInstruction struct {
 	Text     string
 	Path     string
 	Origin   Location
-	scope    Scope
 	Resolver FileResolver
 }
 
-func NewIncludeInstruction(arg string, location Location, original string, scope Scope, resolver FileResolver) *IncludeInstruction {
-	return &IncludeInstruction{Text: original, Path: arg, Origin: location, scope: scope, Resolver: resolver}
+func NewIncludeInstruction(arg string, location Location, original string, resolver FileResolver) *IncludeInstruction {
+	return &IncludeInstruction{Text: original, Path: arg, Origin: location, Resolver: resolver}
 }
 
 func (inc *IncludeInstruction) String() string {
@@ -33,7 +32,7 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, inclus
 			return &MagnanimousError{Code: IOError, message: err.Error()}
 		}
 	} else {
-		inclusionChain = append(inclusionChain, InclusionChainItem{Location: &inc.Origin, scope: inc.scope})
+		inclusionChain = append(inclusionChain, InclusionChainItem{Location: &inc.Origin})
 		//ss:= inclusionChainToString(inclusionChain)
 		//fmt.Printf("Chain: %s", ss)
 		for _, f := range inclusionChain {
@@ -51,9 +50,6 @@ func (inc *IncludeInstruction) Write(writer io.Writer, files WebFilesMap, inclus
 		if err != nil {
 			return err
 		}
-
-		// mix in the context of the include file into the surrounding context
-		webFile.Processed.Context().mixInto(inc.scope.Context())
 	}
 	return nil
 }

--- a/mg/map_context.go
+++ b/mg/map_context.go
@@ -4,7 +4,7 @@ type mapContext struct {
 	ctx map[string]interface{}
 }
 
-func CreateContext() Context {
+func NewContext() Context {
 	m := make(map[string]interface{}, 10)
 	return &mapContext{ctx: m}
 }
@@ -18,6 +18,10 @@ var _ Context = (*mapContext)(nil)
 func (m *mapContext) Get(name string) (interface{}, bool) {
 	v, ok := m.ctx[name]
 	return v, ok
+}
+
+func (m *mapContext) Remove(name string) {
+	delete(m.ctx, name)
 }
 
 func (m *mapContext) Set(name string, value interface{}) {

--- a/mg/map_context.go
+++ b/mg/map_context.go
@@ -1,20 +1,25 @@
 package mg
 
-type MapContext struct {
-	Map map[string]interface{}
+type mapContext struct {
+	ctx map[string]interface{}
 }
 
-var _ Context = (*MapContext)(nil)
+func CreateContext() Context {
+	m := make(map[string]interface{}, 10)
+	return &mapContext{ctx: m}
+}
 
-func (m *MapContext) Get(name string) (interface{}, bool) {
-	v, ok := m.Map[name]
+var _ Context = (*mapContext)(nil)
+
+func (m *mapContext) Get(name string) (interface{}, bool) {
+	v, ok := m.ctx[name]
 	return v, ok
 }
 
-func (m *MapContext) Set(name string, value interface{}) {
-	m.Map[name] = value
+func (m *mapContext) Set(name string, value interface{}) {
+	m.ctx[name] = value
 }
 
-func (m *MapContext) IsEmpty() bool {
-	return len(m.Map) == 0
+func (m *mapContext) IsEmpty() bool {
+	return len(m.ctx) == 0
 }

--- a/mg/map_context.go
+++ b/mg/map_context.go
@@ -1,0 +1,26 @@
+package mg
+
+type MapContext struct {
+	Map map[string]interface{}
+}
+
+var _ Context = (*MapContext)(nil)
+
+func (m *MapContext) Get(name string) (interface{}, bool) {
+	v, ok := m.Map[name]
+	return v, ok
+}
+
+func (m *MapContext) Set(name string, value interface{}) {
+	m.Map[name] = value
+}
+
+func (m *MapContext) IsEmpty() bool {
+	return len(m.Map) == 0
+}
+
+func (m *MapContext) mixInto(other Context) {
+	for k, v := range m.Map {
+		other.Set(k, v)
+	}
+}

--- a/mg/map_context.go
+++ b/mg/map_context.go
@@ -18,9 +18,3 @@ func (m *MapContext) Set(name string, value interface{}) {
 func (m *MapContext) IsEmpty() bool {
 	return len(m.Map) == 0
 }
-
-func (m *MapContext) mixInto(other Context) {
-	for k, v := range m.Map {
-		other.Set(k, v)
-	}
-}

--- a/mg/map_context.go
+++ b/mg/map_context.go
@@ -9,6 +9,10 @@ func CreateContext() Context {
 	return &mapContext{ctx: m}
 }
 
+func ToContext(m map[string]interface{}) Context {
+	return &mapContext{ctx: m}
+}
+
 var _ Context = (*mapContext)(nil)
 
 func (m *mapContext) Get(name string) (interface{}, bool) {

--- a/mg/markdown.go
+++ b/mg/markdown.go
@@ -34,11 +34,11 @@ func (f *HtmlFromMarkdownContent) GetContents() []Content {
 	return f.MarkDownContent
 }
 
-func (f *HtmlFromMarkdownContent) Run(files *WebFilesMap, inclusionChain []InclusionChainItem) {
+func (f *HtmlFromMarkdownContent) Run(files *WebFilesMap, inclusionChain []ContextStackItem) {
 	runSideEffects(f, files, inclusionChain)
 }
 
-func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
+func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
 	htmlHead, main, htmlFooter, err := readMarkdownFileParts(f.MarkDownContent, files, inclusionChain)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, inc
 }
 
 func readMarkdownFileParts(c []Content, files WebFilesMap,
-	inclusionChain []InclusionChainItem) (head, body, foot []byte, err error) {
+	inclusionChain []ContextStackItem) (head, body, foot []byte, err error) {
 	var header, main, footer bytes.Buffer
 	header.Grow(128)
 	main.Grow(1024)

--- a/mg/markdown.go
+++ b/mg/markdown.go
@@ -55,12 +55,23 @@ func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, sta
 	return err
 }
 
+func unwrapMarkdownContent(f *ProcessedFile) ([]Content, bool) {
+	if len(f.contents) == 1 {
+		if md, ok := f.contents[0].(*HtmlFromMarkdownContent); ok {
+			return md.MarkDownContent, true
+		}
+	}
+	return nil, false
+}
+
 func writeAsHtmlAndReset(contents []Content, writer io.Writer, content Content, files WebFilesMap,
 	stack ContextStack) ([]Content, error) {
+	// write contents, converting it to html
 	err := writeAsHtml(contents, writer, files, stack)
 	if err != nil {
 		return nil, err
 	}
+	// write content as it is, returning nil (or empty array)
 	return nil, content.Write(writer, files, stack)
 }
 

--- a/mg/markdown.go
+++ b/mg/markdown.go
@@ -15,7 +15,6 @@ type HtmlFromMarkdownContent struct {
 
 var _ Content = (*HtmlFromMarkdownContent)(nil)
 var _ ContentContainer = (*HtmlFromMarkdownContent)(nil)
-var _ SideEffectContent = (*HtmlFromMarkdownContent)(nil)
 
 var chromaRenderer = blackfriday.WithRenderer(bfchroma.NewRenderer(
 	bfchroma.WithoutAutodetect(), bfchroma.Style("lovelace")))
@@ -38,8 +37,8 @@ func (f *HtmlFromMarkdownContent) Run(files *WebFilesMap, inclusionChain []Conte
 	runSideEffects(f, files, inclusionChain)
 }
 
-func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []ContextStackItem) error {
-	htmlHead, main, htmlFooter, err := readMarkdownFileParts(f.MarkDownContent, files, inclusionChain)
+func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
+	htmlHead, main, htmlFooter, err := readMarkdownFileParts(f.MarkDownContent, files, stack)
 	if err != nil {
 		return err
 	}
@@ -73,8 +72,7 @@ func (f *HtmlFromMarkdownContent) Write(writer io.Writer, files WebFilesMap, inc
 	return nil
 }
 
-func readMarkdownFileParts(c []Content, files WebFilesMap,
-	inclusionChain []ContextStackItem) (head, body, foot []byte, err error) {
+func readMarkdownFileParts(c []Content, files WebFilesMap, stack ContextStack) (head, body, foot []byte, err error) {
 	var header, main, footer bytes.Buffer
 	header.Grow(128)
 	main.Grow(1024)
@@ -113,7 +111,7 @@ func readMarkdownFileParts(c []Content, files WebFilesMap,
 				writer = &main
 			}
 		}
-		err = content.Write(writer, files, inclusionChain)
+		err = content.Write(writer, files, stack)
 		if err != nil {
 			return
 		}

--- a/mg/parameters.go
+++ b/mg/parameters.go
@@ -8,8 +8,7 @@ type magParams struct {
 func (m magParams) Get(name string) (interface{}, bool) {
 	for i := 0; i < m.stack.Size(); i++ {
 		ctx := m.stack.GetContextAt(i)
-		v, ok := ctx.Get(name)
-		if ok {
+		if v, ok := ctx.Get(name); ok {
 			return v, true
 		}
 	}

--- a/mg/parameters.go
+++ b/mg/parameters.go
@@ -2,7 +2,7 @@ package mg
 
 type magParams struct {
 	stack    ContextStack
-	webFiles *WebFilesMap
+	webFiles WebFilesMap
 }
 
 func (m magParams) Get(name string) (interface{}, bool) {

--- a/mg/parameters.go
+++ b/mg/parameters.go
@@ -13,8 +13,5 @@ func (m magParams) Get(name string) (interface{}, bool) {
 			return v, true
 		}
 	}
-	if m.webFiles.GlobalContext != nil {
-		return m.webFiles.GlobalContext.Get(name)
-	}
 	return nil, false
 }

--- a/mg/parameters.go
+++ b/mg/parameters.go
@@ -1,36 +1,20 @@
 package mg
 
 type magParams struct {
-	inclusionChain []InclusionChainItem
-	scope          Scope
-	webFiles       *WebFilesMap
+	stack    ContextStack
+	webFiles *WebFilesMap
 }
 
 func (m magParams) Get(name string) (interface{}, bool) {
-	v, ok := searchParamInScope(m.scope, name)
-	if ok {
-		return v, true
-	}
-	for i := len(m.inclusionChain) - 1; i >= 0; i-- {
-		v, ok = searchParamInScope(m.inclusionChain[i].scope, name)
+	for i := 0; i < m.stack.Size(); i++ {
+		ctx := m.stack.GetContextAt(i)
+		v, ok := ctx.Get(name)
 		if ok {
 			return v, true
 		}
 	}
 	if m.webFiles.GlobalContext != nil {
-		v, ok := m.webFiles.GlobalContext.Get(name)
-		return v, ok
-	}
-	return nil, false
-}
-
-func searchParamInScope(scope Scope, name string) (interface{}, bool) {
-	for scope != nil {
-		v, ok := scope.Context().Get(name)
-		if ok && v != nil {
-			return v, true
-		}
-		scope = scope.Parent()
+		return m.webFiles.GlobalContext.Get(name)
 	}
 	return nil, false
 }

--- a/mg/parser.go
+++ b/mg/parser.go
@@ -4,16 +4,34 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 )
 
 type parserState struct {
-	file    string
-	reader  *bufio.Reader
-	row     uint32
-	col     uint32
-	pf      *ProcessedFile
-	builder *strings.Builder
+	file   string
+	reader *bufio.Reader
+	row    uint32
+	col    uint32
+	//pf           *ProcessedFile
+	builder      *strings.Builder
+	contentStack []ContentContainer
+}
+
+func (state *parserState) append(content Content) {
+	container := state.contentStack[len(state.contentStack)-1]
+	container.AppendContent(content)
+	if c, ok := content.(ContentContainer); ok {
+		state.contentStack = append(state.contentStack, c)
+	}
+}
+
+func (state *parserState) dropStackItem() bool {
+	if len(state.contentStack) > 1 {
+		state.contentStack = state.contentStack[:len(state.contentStack)-1]
+		return true
+	}
+	return false
 }
 
 func parseText(state *parserState, resolver FileResolver) error {
@@ -30,7 +48,7 @@ begin:
 		includeContent = len(strings.TrimSpace(content)) > 0
 	}
 	if includeContent {
-		state.pf.AppendContent(&StringContent{Text: content})
+		state.append(&StringContent{Text: content})
 	}
 	if !eof {
 		err = parseInstruction(state, resolver)
@@ -56,8 +74,8 @@ func parseInstruction(state *parserState, resolver FileResolver) error {
 		state.builder.Reset()
 
 		if len(content) > 0 {
-			appendInstructionContent(state.pf, content,
-				Location{Origin: state.file, Row: instrFirstRow, Col: instrFirstCol},
+			appendInstructionContent(state, content,
+				&Location{Origin: state.file, Row: instrFirstRow, Col: instrFirstCol},
 				resolver)
 		}
 		return nil
@@ -66,6 +84,53 @@ func parseInstruction(state *parserState, resolver FileResolver) error {
 	return NewError(Location{Origin: state.file, Row: state.row, Col: state.col}, ParseError,
 		fmt.Sprintf("instruction started at (%d:%d) was not properly closed with '}}'",
 			instrFirstRow, instrFirstCol))
+}
+
+func appendInstructionContent(state *parserState, text string, location *Location, resolver FileResolver) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	switch len(parts) {
+	case 0:
+		// nothing to do
+	case 1:
+		if parts[0] == "end" {
+			wasDropped := state.dropStackItem()
+			if !wasDropped {
+				log.Printf("WARNING: (%s) %s", location.String(), "end instruction does not match any open scope")
+				state.append(unevaluatedExpression(text))
+			}
+		} else {
+			log.Printf("WARNING: (%s) Instruction missing argument: %s", location.String(), text)
+			state.append(unevaluatedExpression(text))
+		}
+	case 2:
+		content := createInstruction(parts[0], parts[1], location, text, resolver)
+		if content != nil {
+			state.append(content)
+		}
+	}
+}
+
+func createInstruction(name, arg string, location *Location,
+	original string, resolver FileResolver) Content {
+	switch strings.TrimSpace(name) {
+	case "include":
+		return NewIncludeInstruction(arg, location, original, resolver)
+	case "define":
+		return NewVariable(arg, location, original)
+	case "eval":
+		return NewExpression(arg, location, original)
+	case "if":
+		return NewIfInstruction(arg, location, original)
+	case "for":
+		return NewForInstruction(arg, location, original, resolver)
+	case "doc":
+		return nil
+	case "component":
+		return NewComponentInstruction(arg, location, original, resolver)
+	}
+
+	log.Printf("WARNING: (%s) Unknown instruction: '%s'", location.String(), name)
+	return unevaluatedExpression(original)
 }
 
 func parseUntilDoubleRunes(specialRune rune, state *parserState) (bool, error) {

--- a/mg/parser.go
+++ b/mg/parser.go
@@ -127,6 +127,8 @@ func createInstruction(name, arg string, location *Location,
 		return nil
 	case "component":
 		return NewComponentInstruction(arg, location, original, resolver)
+	case "slot":
+		return NewSlotInstruction(arg, location, original)
 	}
 
 	log.Printf("WARNING: (%s) Unknown instruction: '%s'", location.String(), name)

--- a/mg/process.go
+++ b/mg/process.go
@@ -131,11 +131,12 @@ func writeFile(file, targetFile string, wf WebFile, filesMap WebFilesMap, stack 
 }
 
 func (wf *WebFile) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
+	location := Location{Origin: wf.Processed.Path, Col: 0, Row: 0}
+	stack = stack.Push(&location)
 	return writeContents(wf.Processed, writer, files, stack)
 }
 
-func writeContents(cc ContentContainer, writer io.Writer, files WebFilesMap,
-	stack ContextStack) error {
+func writeContents(cc ContentContainer, writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	for _, c := range cc.GetContents() {
 		err := c.Write(writer, files, stack)
 		if err != nil {

--- a/mg/process.go
+++ b/mg/process.go
@@ -131,8 +131,7 @@ func writeFile(file, targetFile string, wf WebFile, filesMap WebFilesMap, stack 
 }
 
 func (wf *WebFile) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
-	location := Location{Origin: wf.Processed.Path, Col: 0, Row: 0}
-	stack = stack.Push(&location)
+	stack = stack.Push(nil)
 	return writeContents(wf.Processed, writer, files, stack)
 }
 
@@ -146,16 +145,16 @@ func writeContents(cc ContentContainer, writer io.Writer, files WebFilesMap, sta
 	return nil
 }
 
-func inclusionChainToString(locations []ContextStackItem) string {
+func inclusionChainToString(stackItems []ContextStackItem) string {
 	var b strings.Builder
 	b.WriteRune('[')
-	last := len(locations) - 1
-	for i, loc := range locations {
-		b.WriteString(loc.Location.String())
-		if i != last {
-			b.WriteString(" -> ")
+	var includes []string
+	for _, loc := range stackItems {
+		if loc.Location != nil {
+			includes = append(includes, loc.Location.String())
 		}
 	}
+	b.WriteString(strings.Join(includes, " -> "))
 	b.WriteRune(']')
 	return b.String()
 }

--- a/mg/process.go
+++ b/mg/process.go
@@ -76,7 +76,7 @@ func ProcessReader(reader *bufio.Reader, file string, sizeHint int, resolver Fil
 }
 
 func WriteTo(dir string, filesMap WebFilesMap) error {
-	stack := ContextStack{}
+	stack := NewContextStack(CreateContext())
 	if globalCtx, ok := filesMap.WebFiles["source/_global_context"]; ok {
 		ctx := globalCtx.Processed.ResolveContext(filesMap, stack)
 		stack = NewContextStack(ctx)

--- a/mg/slot.go
+++ b/mg/slot.go
@@ -28,7 +28,7 @@ func NewSlotInstruction(arg string, location *Location, original string) Content
 
 func (s *SlotContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	// slot does not write anything, it must be evaluated to resolve its body
-	stack.Top().Context.Set(s.Name, s)
+	stack.Top().Set(s.Name, s)
 	return nil
 }
 

--- a/mg/slot.go
+++ b/mg/slot.go
@@ -1,0 +1,41 @@
+package mg
+
+import (
+	"io"
+	"log"
+	"strings"
+)
+
+type SlotContent struct {
+	Name     string
+	Text     string
+	Location *Location
+	contents []Content
+}
+
+var _ Content = (*SlotContent)(nil)
+var _ ContentContainer = (*SlotContent)(nil)
+
+func NewSlotInstruction(arg string, location *Location, original string) Content {
+	parts := strings.SplitN(strings.TrimSpace(arg), " ", 2)
+	if len(parts) == 1 {
+		variable := parts[0]
+		return &SlotContent{Name: variable, Location: location}
+	}
+	log.Printf("WARNING: (%s) malformed slot instruction: %s", location.String(), arg)
+	return unevaluatedExpression(original)
+}
+
+func (s *SlotContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
+	// slot does not write anything, it must be evaluated to resolve its body
+	stack.Top().Context.Set(s.Name, s)
+	return nil
+}
+
+func (s *SlotContent) GetContents() []Content {
+	return s.contents
+}
+
+func (s *SlotContent) AppendContent(content Content) {
+	s.contents = append(s.contents, content)
+}

--- a/mg/string.go
+++ b/mg/string.go
@@ -1,0 +1,22 @@
+package mg
+
+import (
+	"fmt"
+	"io"
+)
+
+type StringContent struct {
+	Text string
+}
+
+func (c *StringContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
+	_, err := writer.Write([]byte(c.Text))
+	if err != nil {
+		return &MagnanimousError{Code: IOError, message: err.Error()}
+	}
+	return nil
+}
+
+func (c *StringContent) String() string {
+	return fmt.Sprintf("StringContent{%s}", c.Text)
+}

--- a/mg/string.go
+++ b/mg/string.go
@@ -9,7 +9,7 @@ type StringContent struct {
 	Text string
 }
 
-func (c *StringContent) Write(writer io.Writer, files WebFilesMap, inclusionChain []InclusionChainItem) error {
+func (c *StringContent) Write(writer io.Writer, files WebFilesMap, stack ContextStack) error {
 	_, err := writer.Write([]byte(c.Text))
 	if err != nil {
 		return &MagnanimousError{Code: IOError, message: err.Error()}

--- a/mg/types.go
+++ b/mg/types.go
@@ -119,7 +119,7 @@ func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Co
 			}
 		}
 	}
-	return &MapContext{ctx}
+	return CreateContext()
 }
 
 // Bytes returns the bytes of the processed file.

--- a/mg/types.go
+++ b/mg/types.go
@@ -74,7 +74,7 @@ type ContentContainer interface {
 // Implementations of Content define how Magnanimous instructions behave.
 // A Content may contain nested Content parts, in which case it implements ContentContainer.
 type Content interface {
-	// Write writes its contents using the given writer.
+	// Write contents using the given writer.
 	//
 	// The files argument contains all parsed source files.
 	//

--- a/mg/types.go
+++ b/mg/types.go
@@ -119,7 +119,7 @@ func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Co
 			}
 		}
 	}
-	return CreateContext()
+	return ToContext(ctx)
 }
 
 // Bytes returns the bytes of the processed file.

--- a/mg/types.go
+++ b/mg/types.go
@@ -128,9 +128,13 @@ func (f *ProcessedFile) Bytes(files WebFilesMap, stack ContextStack) ([]byte, er
 }
 
 func body(c ContentContainer, files WebFilesMap, stack ContextStack) ([]byte, error) {
+	return asBytes(c.GetContents(), files, stack)
+}
+
+func asBytes(c []Content, files WebFilesMap, stack ContextStack) ([]byte, error) {
 	var b bytes.Buffer
 	b.Grow(512)
-	for _, c := range c.GetContents() {
+	for _, c := range c {
 		if c != nil {
 			err := c.Write(&b, files, stack)
 			if err != nil {

--- a/mg/types.go
+++ b/mg/types.go
@@ -124,10 +124,13 @@ func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Co
 
 // Bytes returns the bytes of the processed file.
 func (f *ProcessedFile) Bytes(files WebFilesMap, stack ContextStack) ([]byte, error) {
-	stack = stack.Push(&Location{Origin: f.Path, Row: 0, Col: 0})
+	return body(f, files, stack)
+}
+
+func body(c ContentContainer, files WebFilesMap, stack ContextStack) ([]byte, error) {
 	var b bytes.Buffer
 	b.Grow(512)
-	for _, c := range f.contents {
+	for _, c := range c.GetContents() {
 		if c != nil {
 			err := c.Write(&b, files, stack)
 			if err != nil {

--- a/mg/types.go
+++ b/mg/types.go
@@ -17,7 +17,6 @@ type Magnanimous struct {
 
 // WebFilesMap contains the result of reading a source directory with ReadAll().
 type WebFilesMap struct {
-	GlobalContext RootContext
 	// WebFiles is a map from each file path to the parsed WebFile.
 	WebFiles map[string]WebFile
 }
@@ -97,8 +96,6 @@ type ProcessedFile struct {
 	NewExtension string
 	Path         string
 }
-
-type RootContext Context
 
 var _ ContentContainer = (*ProcessedFile)(nil)
 

--- a/mg/types.go
+++ b/mg/types.go
@@ -111,7 +111,7 @@ func (f *ProcessedFile) AppendContent(content Content) {
 // of the [ProcessedFile].
 func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Context {
 	ctx := make(map[string]interface{})
-	for _, c := range f.contents {
+	for _, c := range f.expandedContents() {
 		if content, ok := c.(*DefineContent); ok {
 			v, ok := content.Eval(files, stack)
 			if ok {
@@ -125,6 +125,14 @@ func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Co
 // Bytes returns the bytes of the processed file.
 func (f *ProcessedFile) Bytes(files WebFilesMap, stack ContextStack) ([]byte, error) {
 	return body(f, files, stack)
+}
+
+func (f *ProcessedFile) expandedContents() []Content {
+	// expand contents in case this is markdown
+	if c, ok := unwrapMarkdownContent(f); ok {
+		return c
+	}
+	return f.contents
 }
 
 func body(c ContentContainer, files WebFilesMap, stack ContextStack) ([]byte, error) {

--- a/mg/types.go
+++ b/mg/types.go
@@ -40,16 +40,8 @@ type Location struct {
 //
 // Used to keep state when writing nested Content.
 type ContextStack struct {
-	chain []ContextStackItem
-}
-
-// ContextStackItem is an object that contains the local Context and Location.
-//
-// It is used by Content implementations to write their contents using the given context to resolve data.
-// Content implementations that create new scopes must add an item to the ContextStack.
-type ContextStackItem struct {
-	Location *Location
-	Context  Context
+	locations []Location
+	contexts  []Context
 }
 
 // FileResolver defines how Magnanimous finds source files.
@@ -87,6 +79,7 @@ type Content interface {
 type Context interface {
 	Get(name string) (interface{}, bool)
 	Set(name string, value interface{})
+	Remove(name string)
 	IsEmpty() bool
 }
 

--- a/mg/types.go
+++ b/mg/types.go
@@ -119,7 +119,7 @@ func (f *ProcessedFile) ResolveContext(files WebFilesMap, stack ContextStack) Co
 			}
 		}
 	}
-	return &mapContext{ctx}
+	return &MapContext{ctx}
 }
 
 // Bytes returns the bytes of the processed file.

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -27,10 +27,6 @@ func TestCopy(t *testing.T) {
 		t.Errorf("Expected basePath 'b' but was '%s'", result.BasePath)
 	}
 
-	if !result.Processed.Context().IsEmpty() {
-		t.Errorf("Expected empty context but was %v", result.Processed.Context())
-	}
-
 	contents := result.Processed.GetContents()
 
 	if len(contents) != 1 {
@@ -39,7 +35,7 @@ func TestCopy(t *testing.T) {
 
 	w := strings.Builder{}
 	m := mg.WebFilesMap{}
-	me := contents[0].Write(&w, m, nil)
+	me := contents[0].Write(&w, m, mg.ContextStack{})
 
 	if me != nil {
 		t.Fatal(me)

--- a/tests/define_test.go
+++ b/tests/define_test.go
@@ -18,7 +18,7 @@ func TestDefineNumber(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["a"] = float64(2)
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{""})
 }
 
 func TestDefineString(t *testing.T) {
@@ -32,7 +32,7 @@ func TestDefineString(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["title"] = "My Site"
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{""})
 }
 
 func TestDefineStringConcat(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDefineStringConcat(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["title"] = "My Site"
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{""})
 }
 
 func TestDefineFromExpression(t *testing.T) {
@@ -60,7 +60,7 @@ func TestDefineFromExpression(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["n"] = float64(70)
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{""})
 }
 
 func TestDefineFromOrExpression(t *testing.T) {
@@ -74,7 +74,7 @@ func TestDefineFromOrExpression(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["n"] = "alternative"
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{""})
 }
 
 func TestDefineBasedOnPreviousDefine(t *testing.T) {
@@ -93,7 +93,7 @@ func TestDefineBasedOnPreviousDefine(t *testing.T) {
 	expectedCtx["b"] = float64(4)
 	expectedCtx["c"] = float64(40)
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, expectedCtx, []string{"", "", ""})
+	checkParsing(t, emptyFilesMap, processed, expectedCtx, []string{"", "", ""})
 }
 
 func TestMalformedDefine(t *testing.T) {
@@ -104,7 +104,7 @@ func TestMalformedDefine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, emptyContext, []string{"{{ define }}"})
+	checkParsing(t, emptyFilesMap, processed, emptyContext, []string{"{{ define }}"})
 
 	r = bufio.NewReader(strings.NewReader("{{ define abc }}"))
 	processed, err = mg.ProcessReader(r, "source/processed/hi.html", 11, nil)
@@ -113,5 +113,5 @@ func TestMalformedDefine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, emptyContext, []string{"{{ define abc }}"})
+	checkParsing(t, emptyFilesMap, processed, emptyContext, []string{"{{ define abc }}"})
 }

--- a/tests/error_test.go
+++ b/tests/error_test.go
@@ -58,7 +58,8 @@ func TestInclusionIndirectCycleError(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 
-	magErr := mg.WriteTo(dir, *resolver.Files)
+	mag := mg.Magnanimous{}
+	magErr := mag.WriteTo(dir, *resolver.Files)
 
 	shouldHaveError(t, magErr, mg.InclusionCycleError, "Cycle detected! Inclusion of "+
 		"/processed/other.txt at /processed/hi.txt:1:5 "+
@@ -89,7 +90,8 @@ func TestInclusionSelfCycleError(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 
-	magErr := mg.WriteTo(dir, *resolver.Files)
+	mag := mg.Magnanimous{}
+	magErr := mag.WriteTo(dir, *resolver.Files)
 
 	shouldHaveError(t, magErr, mg.InclusionCycleError, "Cycle detected! Inclusion of "+
 		"hi.txt at source/processed/hi.txt:1:5 "+

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -15,7 +15,7 @@ func TestEvalString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, emptyContext, []string{"Hello ", "Joe"})
+	checkParsing(t, emptyFilesMap, processed, emptyContext, []string{"Hello ", "Joe"})
 }
 
 func TestEvalArithmetic(t *testing.T) {
@@ -26,7 +26,7 @@ func TestEvalArithmetic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, emptyContext, []string{"2 + 2 * 5 == ", "12"})
+	checkParsing(t, emptyFilesMap, processed, emptyContext, []string{"2 + 2 * 5 == ", "12"})
 }
 
 func TestEvalNonExistingParameter(t *testing.T) {
@@ -37,7 +37,7 @@ func TestEvalNonExistingParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, processed.Context(), emptyFilesMap, processed, emptyContext, []string{"{{ eval 2 * a }}"})
+	checkParsing(t, emptyFilesMap, processed, emptyContext, []string{"{{ eval 2 * a }}"})
 }
 
 func TestEvalWithExistingParameter(t *testing.T) {
@@ -54,7 +54,7 @@ func TestEvalWithExistingParameter(t *testing.T) {
 	files := mg.WebFilesMap{WebFiles: make(map[string]mg.WebFile, 1)}
 	files.WebFiles["source/processed/hi.md"] = mg.WebFile{Processed: processed}
 
-	checkParsing(t, processed.Context(), files, processed, expectedCtx, []string{"<p>6</p>\n"})
+	checkParsing(t, files, processed, expectedCtx, []string{"<p>6</p>\n"})
 }
 
 func TestEvalWithOrExprParameterExists(t *testing.T) {
@@ -71,7 +71,7 @@ func TestEvalWithOrExprParameterExists(t *testing.T) {
 	files := mg.WebFilesMap{WebFiles: make(map[string]mg.WebFile, 1)}
 	files.WebFiles["source/processed/hi.md"] = mg.WebFile{Processed: processed}
 
-	checkParsing(t, processed.Context(), files, processed, expectedCtx, []string{"<p>3</p>\n"})
+	checkParsing(t, files, processed, expectedCtx, []string{"<p>3</p>\n"})
 }
 
 func TestEvalWithOrExprParameterDoesNotExist(t *testing.T) {
@@ -87,7 +87,7 @@ func TestEvalWithOrExprParameterDoesNotExist(t *testing.T) {
 	files := mg.WebFilesMap{WebFiles: make(map[string]mg.WebFile, 1)}
 	files.WebFiles["source/processed/hi.md"] = mg.WebFile{Processed: processed}
 
-	checkParsing(t, processed.Context(), files, processed, expectedCtx, []string{"<p>100</p>\n"})
+	checkParsing(t, files, processed, expectedCtx, []string{"<p>100</p>\n"})
 }
 
 func TestEvalWithExistingParameterFromAnotherFile(t *testing.T) {
@@ -114,7 +114,7 @@ func TestEvalWithExistingParameterFromAnotherFile(t *testing.T) {
 	expectedCtx := make(map[string]interface{})
 	expectedCtx["hello"] = float64(7)
 
-	checkParsing(t, otherProcessed.Context(), *resolver.Files, otherProcessed, expectedCtx, []string{
+	checkParsing(t, *resolver.Files, otherProcessed, expectedCtx, []string{
 		"OUTER\n",
 		"",
 		"A = 14",

--- a/tests/files_test.go
+++ b/tests/files_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ResolveFile(file, origin string) string {
-	return mg.Resolve(file, "source", mg.Location{Origin: origin})
+	return mg.Resolve(file, "source", &mg.Location{Origin: origin})
 }
 
 func TestResolveFile(t *testing.T) {

--- a/tests/for_test.go
+++ b/tests/for_test.go
@@ -176,7 +176,7 @@ func TestForArrayInMarkDown(t *testing.T) {
 	}
 
 	checkContents(t, emptyFilesMap, processed,
-		"\n<h2>Home</h2>\n\n"+
+		"<h2>Home</h2>\n\n"+
 			"<p>Something something</p>\n\n"+
 			"<h2>About</h2>\n\n"+
 			"<p>Something something\n"+

--- a/tests/for_test.go
+++ b/tests/for_test.go
@@ -186,9 +186,9 @@ func TestForArrayInMarkDown(t *testing.T) {
 func TestForFiles(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "File 1"},
-		"processed/examples/f2.txt": {"title": "Second File"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{ define title \"File 1\" }}",
+		"processed/examples/f2.txt": "{{ define title \"Second File\" }}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -213,8 +213,8 @@ func TestForFiles(t *testing.T) {
 func TestForFilesScope(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "File 1"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{ define title \"File 1\" }}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -242,11 +242,11 @@ func TestForFilesScope(t *testing.T) {
 func TestForFilesWithUnwritableFiles(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "File 1"},
-		"processed/examples/_a.txt": {"title": "?"},
-		"processed/examples/f2.txt": {"title": "Second File"},
-		"processed/examples/_b.txt": {"title": "?"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{ define title \"File 1\" }}",
+		"processed/examples/_a.txt": "{{ define title \"?\" }}",
+		"processed/examples/f2.txt": "{{ define title \"Second File\" }}",
+		"processed/examples/_b.txt": "{{ define title \"?\" }}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -271,14 +271,14 @@ func TestForFilesWithUnwritableFiles(t *testing.T) {
 func TestForFilesReverse(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/a.txt": {"title": "A"},
-		"processed/b.txt": {"title": "B"},
-		"processed/g.txt": {"title": "G"},
-		"processed/f.txt": {"title": "F"},
-		"processed/c.txt": {"title": "C"},
-		"processed/e.txt": {"title": "E"},
-		"processed/d.txt": {"title": "D"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/a.txt": "{{ define title \"A\"}}",
+		"processed/b.txt": "{{ define title \"B\"}}",
+		"processed/g.txt": "{{ define title \"G\"}}",
+		"processed/f.txt": "{{ define title \"F\"}}",
+		"processed/c.txt": "{{ define title \"C\"}}",
+		"processed/e.txt": "{{ define title \"E\"}}",
+		"processed/d.txt": "{{ define title \"D\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -308,14 +308,14 @@ func TestForFilesReverse(t *testing.T) {
 func TestForFilesLimit(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/a.txt": {"title": "A"},
-		"processed/b.txt": {"title": "B"},
-		"processed/g.txt": {"title": "G"},
-		"processed/f.txt": {"title": "F"},
-		"processed/c.txt": {"title": "C"},
-		"processed/e.txt": {"title": "E"},
-		"processed/d.txt": {"title": "D"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/a.txt": "{{define title \"A\"}}",
+		"processed/b.txt": "{{define title \"B\"}}",
+		"processed/g.txt": "{{define title \"G\"}}",
+		"processed/f.txt": "{{define title \"F\"}}",
+		"processed/c.txt": "{{define title \"C\"}}",
+		"processed/e.txt": "{{define title \"E\"}}",
+		"processed/d.txt": "{{define title \"D\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -343,10 +343,10 @@ func TestForFilesLimit(t *testing.T) {
 func TestForFilesLimitTooMany(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/a.txt": {"title": "A"},
-		"processed/b.txt": {"title": "B"},
-		"processed/c.txt": {"title": "C"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/a.txt": "{{define title \"A\"}}",
+		"processed/b.txt": "{{define title \"B\"}}",
+		"processed/c.txt": "{{define title \"C\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -372,12 +372,12 @@ func TestForFilesLimitTooMany(t *testing.T) {
 func TestForFilesSortBy(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "Some file"},
-		"processed/examples/f2.txt": {"title": "Other file"},
-		"processed/examples/f3.txt": {"title": "A file"},
-		"processed/examples/f4.txt": {"title": "Z file"},
-		"processed/examples/f5.txt": {"title": "Final"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{define title \"Some file\"}}",
+		"processed/examples/f2.txt": "{{define title \"Other file\"}}",
+		"processed/examples/f3.txt": "{{define title \"A file\"}}",
+		"processed/examples/f4.txt": "{{define title \"Z file\"}}",
+		"processed/examples/f5.txt": "{{define title \"Final\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -405,12 +405,12 @@ func TestForFilesSortBy(t *testing.T) {
 func TestForFilesSortByReverse(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "Some file"},
-		"processed/examples/f2.txt": {"title": "Other file"},
-		"processed/examples/f3.txt": {"title": "A file"},
-		"processed/examples/f4.txt": {"title": "Z file"},
-		"processed/examples/f5.txt": {"title": "Final"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{define title \"Some file\"}}",
+		"processed/examples/f2.txt": "{{define title \"Other file\"}}",
+		"processed/examples/f3.txt": "{{define title \"A file\"}}",
+		"processed/examples/f4.txt": "{{define title \"Z file\"}}",
+		"processed/examples/f5.txt": "{{define title \"Final\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -438,12 +438,12 @@ func TestForFilesSortByReverse(t *testing.T) {
 func TestForFilesReverseSortBy(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "Some file"},
-		"processed/examples/f2.txt": {"title": "Other file"},
-		"processed/examples/f3.txt": {"title": "A file"},
-		"processed/examples/f4.txt": {"title": "Z file"},
-		"processed/examples/f5.txt": {"title": "Final"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{define title \"Some file\"}}",
+		"processed/examples/f2.txt": "{{define title \"Other file\"}}",
+		"processed/examples/f3.txt": "{{define title \"A file\"}}",
+		"processed/examples/f4.txt": "{{define title \"Z file\"}}",
+		"processed/examples/f5.txt": "{{define title \"Final\"}}",
 	})
 	defer os.RemoveAll(dir)
 
@@ -471,12 +471,12 @@ func TestForFilesReverseSortBy(t *testing.T) {
 func TestForFilesLimitSortByReverse(t *testing.T) {
 
 	// create a bunch of files for testing
-	files, dir := CreateTempFiles(map[string]map[string]string{
-		"processed/examples/f1.txt": {"title": "Other file"},
-		"processed/examples/f2.txt": {"title": "Some file"},
-		"processed/examples/f3.txt": {"title": "A file"},
-		"processed/examples/f4.txt": {"title": "Z file"},
-		"processed/examples/f5.txt": {"title": "Final"},
+	files, dir := CreateTempFiles(map[string]string{
+		"processed/examples/f1.txt": "{{define title \"Some file\"}}",
+		"processed/examples/f2.txt": "{{define title \"Other file\"}}",
+		"processed/examples/f3.txt": "{{define title \"A file\"}}",
+		"processed/examples/f4.txt": "{{define title \"Z file\"}}",
+		"processed/examples/f5.txt": "{{define title \"Final\"}}",
 	})
 	defer os.RemoveAll(dir)
 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -113,7 +113,7 @@ func checkParsing(t *testing.T,
 			len(expectedContents), len(contents), contents)
 	}
 
-	ctx := mg.CreateContext()
+	ctx := mg.NewContext()
 	stack := mg.NewContextStack(ctx)
 
 	for i, c := range contents {
@@ -153,7 +153,7 @@ func checkContents(t *testing.T,
 	m mg.WebFilesMap, pf *mg.ProcessedFile,
 	expectedContent string) {
 
-	ctx := mg.CreateContext()
+	ctx := mg.NewContext()
 	stack := mg.NewContextStack(ctx)
 
 	content, err := pf.Bytes(m, stack)
@@ -179,7 +179,7 @@ func runMg(t *testing.T, project string) string {
 		t.Fatal(err)
 	}
 
-	err = mg.WriteTo(dir, webFiles)
+	err = mag.WriteTo(dir, webFiles)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/renatoathaydes/magnanimous/mg"
 	"io/ioutil"
@@ -82,8 +83,11 @@ func CreateTempFiles(files map[string]string) (mg.WebFilesMap, string) {
 		check(err)
 		_, err = file.Write([]byte(content))
 		check(err)
+		fileReader := bufio.NewReader(strings.NewReader(content))
+		pf, err := mg.ProcessReader(fileReader, name, len(content), nil)
+		check(err)
 		filesMap.WebFiles[filepath.Join(dir, name)] = mg.WebFile{
-			Processed:   &mg.ProcessedFile{},
+			Processed:   pf,
 			Name:        filepath.Base(name),
 			NonWritable: strings.HasPrefix(filepath.Base(name), "_"),
 		}

--- a/tests/process_test.go
+++ b/tests/process_test.go
@@ -11,7 +11,7 @@ func TestMarkdownEngineAlwaysMakesTheSameThing(t *testing.T) {
 	contents := []mg.Content{&mg.StringContent{Text: "# hello\n## world"}}
 
 	writeContentToString := func(content mg.Content) string {
-		stack := mg.NewContextStack(mg.CreateContext())
+		stack := mg.NewContextStack(mg.NewContext())
 		var w strings.Builder
 		err := content.Write(&w, mg.WebFilesMap{}, stack)
 		check(err)
@@ -81,7 +81,7 @@ func TestMarkdownToHtml(t *testing.T) {
 
 	html := mg.MarkdownToHtml(file)
 
-	stack := mg.NewContextStack(mg.CreateContext())
+	stack := mg.NewContextStack(mg.NewContext())
 	result, err := html.Bytes(m, stack)
 
 	if err != nil {

--- a/tests/process_test.go
+++ b/tests/process_test.go
@@ -24,7 +24,7 @@ func TestMarkdownEngineAlwaysMakesTheSameThing(t *testing.T) {
 		markdown := mg.HtmlFromMarkdownContent{MarkDownContent: contents}
 		r := writeContentToString(&markdown)
 		if r != expectedResult {
-			t.Errorf("[%d] '%s' != %s", i, string(r), expectedResult)
+			t.Errorf("[%d] '%s' != '%s'", i, string(r), expectedResult)
 		}
 	}
 }
@@ -114,7 +114,7 @@ func TestProcessIncludeMarkDown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkParsing(t, m, processed, emptyContext, []string{"<h1>hello</h1>\n\n<h2>header</h2>\n"})
+	checkParsing(t, m, processed, emptyContext, []string{"<h1>hello</h1>\n<h2>header</h2>\n"})
 }
 
 func TestProcessIgnoreEscapedBrackets(t *testing.T) {

--- a/tests/proj_test.go
+++ b/tests/proj_test.go
@@ -71,8 +71,7 @@ func TestProj3(t *testing.T) {
 	}
 
 	assertFileContents(t, files, dir, "index.html",
-		`<link rel="stylesheet" href="/style.css">
-<h1>Welcome</h1>
+		`<link rel="stylesheet" href="/style.css"><h1>Welcome</h1>
 
 <p><div class ="interessant">This is a website.</div>
 My blog posts:</p>
@@ -82,13 +81,11 @@ My blog posts:</p>
 
 <li><p>05 July 2018 - One more blog post</p></li>
 </ul>
-
 <h4>the footer</h4>
 `)
 
 	assertFileContents(t, files, dir, "posts/p1.html",
-		`<link rel="stylesheet" href="/style.css">
-<h2>Post 1</h2>
+		`<link rel="stylesheet" href="/style.css"><h2>Post 1</h2>
 
 <p>Hello.</p>
 
@@ -100,8 +97,7 @@ My blog posts:</p>
 `)
 
 	assertFileContents(t, files, dir, "posts/p2.html",
-		`<link rel="stylesheet" href="/style.css">
-<h2>Post 2</h2>
+		`<link rel="stylesheet" href="/style.css"><h2>Post 2</h2>
 
 <p>Short one.</p>
 `)
@@ -137,8 +133,7 @@ func TestProj4(t *testing.T) {
     <title>My blog</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h1>Welcome</h1>
+<body><h1>Welcome</h1>
 
 <p><div class ="interessant">This is a website.</div>
 My blog posts:</p>
@@ -165,13 +160,10 @@ My blog posts:</p>
     <title>My first blog post</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h2>Post 1</h2>
+<body><h2>Post 1</h2>
 
 <p>Hello.</p>
-
 <blockquote>Note: This is a note.</blockquote>
-
 <p>Bye.</p>
 <h4>the footer</h4>
 </body>
@@ -186,8 +178,7 @@ My blog posts:</p>
     <title>One more blog post</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h2>Post 2</h2>
+<body><h2>Post 2</h2>
 
 <p>Short one.</p>
 <h4>the footer</h4>
@@ -203,8 +194,7 @@ My blog posts:</p>
     <title>Potatoes</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h2>Potatoes</h2>
+<body><h2>Potatoes</h2>
 
 <p>Potatoes are nice.</p>
 <h4>the footer</h4>
@@ -220,8 +210,7 @@ My blog posts:</p>
     <title>Capsicum</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h2>Capsicum</h2>
+<body><h2>Capsicum</h2>
 
 <p>Capsicum is good.</p>
 <h4>the footer</h4>
@@ -237,8 +226,7 @@ My blog posts:</p>
     <title>Broccoli</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-<h2>Broccoli and you</h2>
+<body><h2>Broccoli and you</h2>
 
 <p>You should eat more broccoli.</p>
 <h4>the footer</h4>
@@ -279,7 +267,7 @@ func TestProj5(t *testing.T) {
 	assertFileContents(t, files, dir, "scopes.txt", "Base URL: /my-website/\n\n"+
 		"/other-website/A\n"+
 		"/other-website/<nil>\n\n"+
-		"File sees /my-website/\n"+
+		"File sees /other-website/\n"+
 		"Full path: /other-website/folder/example.txt\n"+
 		"After unset, base URL: /my-website/")
 }
@@ -332,7 +320,7 @@ func benchmarkProject(b *testing.B, project string) {
 	}
 
 	for _, webFile := range webFiles.WebFiles {
-		stack := mg.NewContextStack(mg.CreateContext())
+		stack := mg.NewContextStack(mg.NewContext())
 		var w strings.Builder
 		err = webFile.Write(&w, webFiles, stack)
 

--- a/tests/proj_test.go
+++ b/tests/proj_test.go
@@ -332,8 +332,9 @@ func benchmarkProject(b *testing.B, project string) {
 	}
 
 	for _, webFile := range webFiles.WebFiles {
+		stack := mg.NewContextStack(mg.CreateContext())
 		var w strings.Builder
-		err = webFile.Write(&w, webFiles, nil)
+		err = webFile.Write(&w, webFiles, stack)
 
 		if err != nil {
 			b.Fatal(err)

--- a/website/source/processed/sections/docs/components.md
+++ b/website/source/processed/sections/docs/components.md
@@ -11,7 +11,10 @@ footers.
 
 To avoid repeating the same code all over the place, you can use Magnanimous components.
 
-## Creating and using a component
+{{ component /processed/components/_linked_header.html }}\
+{{ define id "creating-and-using-component" }}\
+Creating and using a component
+{{ end }}
 
 A component should normally be declared in a non-writable file (i.e. its name starts with underscore, as in `_example`)
 somewhere under the `source/processed/` directory.
@@ -61,21 +64,24 @@ Which should render like this:
 <div>More content</div>
 ```
 
-### Customizing components with variables
+{{ component /processed/components/_linked_header.html }}\
+{{ define id "customizing-components-with-variables" }}\
+Customizing components with variables
+{{ end }}
 
 Components allow the user to declare variables that customize its contents. The variables may be declared before the
 component's declaration, but they can also be placed inside the component's body, making the variables "local" to the
 component (i.e. not visible in the surrounding scope).
 
 Let's look at an example to clarify what that means. This component expects 2 variables (`my_variable` and `other_var`)
-to be set for customizing it: 
+to be set for customizing it:
 
 ```html
 <h2>\{{ eval my_variable }}</h2>
 <div>
     <span>\{{ eval other_var }}</span>
 </div>
-``` 
+```
 
 {{ component /processed/components/_file-box.html }}\
     {{ define file "source/processed/components/_var_example.html" }}
@@ -102,7 +108,10 @@ Result:
 </div>
 ```
 
-### Customizing components with slots
+{{ component /processed/components/_linked_header.html }}\
+{{ define id "customizing-components-with-slots" }}\
+Customizing components with slots
+{{ end }}
 
 `slot`s make components extremely powerful! They allow the creation of very modular components.
 
@@ -134,7 +143,10 @@ To use this component is pretty easy:
 \{{ end }}
 ```
 
-### A more advanced example
+{{ component /processed/components/_linked_header.html }}\
+{{ define id "advanced-example" }}\
+A more advanced example
+{{ end }}
 
 To really understand what can be achieved with components, let's look at a more advanced example.
 

--- a/website/source/processed/sections/docs/components.md
+++ b/website/source/processed/sections/docs/components.md
@@ -13,65 +13,126 @@ To avoid repeating the same code all over the place, you can use Magnanimous com
 
 ## Creating and using a component
 
-A component should be declared in a non-writable file (i.e. its name starts with underscore, as in `_example`)
-somewhere under the `source/processed/` directory. That's because components are not usually full HTML pages,
-but fragments which can be customized to display different content, sometimes even in a customizable shape
-(so you wouldn't want them served by the server by themselves).
+A component should normally be declared in a non-writable file (i.e. its name starts with underscore, as in `_example`)
+somewhere under the `source/processed/` directory.
+
+That's because components are not usually full HTML pages, but fragments which can be customized to display 
+customizable content (so you wouldn't want them served by the server by themselves, without "filling" it in).
 
 As an example, let's say we want to create a component to represent a simple _warning_ box.
 
 It could look like this:
 
 ```html
-\{{ doc This component takes a 'message' and displays it in a warning box }}\\
-<div class="warning">\{{ eval message }}</div>
+\{{ doc This component takes its contents and displays it in a warning box }}\\
+<div class="warning">\{{ eval __contents__ }}</div>
 ```
 
 {{ component /processed/components/_file-box.html }}\
     {{ define file "source/processed/components/_warning.html" }}
 {{ end }}
 
+> Notice that `__contents__` is a special variable that holds the contents of the component when it's used
+  (i.e. the content wrapped between \{{ component path }} and \{{ end }} as we'll see below).
+
 That's it!
 
-You could then use this component in other files like this:
+You could then use this component in other processed files like this:
 
 ```html
 <div>Some content</div>
 
 \{{ component /processed/components/_warning.html }}
-    Warning Box!! This text is ignored, only definitions in this scope are evaluated.
-    \{{ define message "This is a warning message!" }}
+    This is a warning message!
 \{{ end }}
 
 <div>More content</div>
 ```
 
-> Notice that all customizable components must go in the `source/processed/` directory (so they can receive
-  the customization via variables), but where under that directory does not matter for Magnanimous... they could
-  go under any sub-directory you wish. If you create static components that don't need to be customized,
-  you could even put them under `source/static`, which guarantees they will be included without changes.
-
-### Component scopes
-
-Notice that our example component expects a variable called `message` to exist in its scope. For that reason, 
-in the above example, we provide a `message` binding within the scope of the component itself, so that we don't
-mess with the surrounding scope.
-
-If that's not a concern, we could have just re-used an existing binding, as in this example:
+Which should render like this:
 
 ```html
-\{{ define message "This is a warning message!" }}\\
 <div>Some content</div>
 
-\{{ component /processed/components/_warning.html }}\{{ end }}
+<div class="warning">
+    This is a warning message!
+</div>
 
 <div>More content</div>
 ```
 
-Notice that the usual scope rules which apply to file inclusions also apply to components.
+### Customizing components with variables
 
-So, the `message` variable for the example component could even have come from another file which includes this file,
-or ultimately, from the `_global_context`.
+Components allow the user to declare variables that customize its contents. The variables may be declared before the
+component's declaration, but they can also be placed inside the component's body, making the variables "local" to the
+component (i.e. not visible in the surrounding scope).
+
+Let's look at an example to clarify what that means. This component expects 2 variables (`my_variable` and `other_var`)
+to be set for customizing it: 
+
+```html
+<h2>\{{ eval my_variable }}</h2>
+<div>
+    <span>\{{ eval other_var }}</span>
+</div>
+``` 
+
+{{ component /processed/components/_file-box.html }}\
+    {{ define file "source/processed/components/_var_example.html" }}
+{{ end }}
+
+When using it, we need to provide values for both variables, which we can do both from outside and from inside the
+component:
+
+```html
+\{{ define my_variable "This is available in the component's scope" }}\\
+
+\{{ component /processed/components/_var_example.html }}
+    \{{ define other_var "This also!" }}\\
+\{{ end }}
+```
+
+Result:
+
+```html
+
+<h2>This is available in the component's scope</h2>
+<div>
+    <span>This also!</span>
+</div>
+```
+
+### Customizing components with slots
+
+`slot`s make components extremely powerful! They allow the creation of very modular components.
+
+> Slots are inspired by the HTML5 
+  [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) standard.
+
+For example, we can create a component that places its contents in 3 areas: top, middle and bottom
+(where both top and bottom are optional):
+
+```html
+<div class="top">\{{ eval top || "" }}</div>
+<div class="middle">\{{ eval middle }}</div>
+<div class="bottom">\{{ eval bottom || "" }}</div>
+```
+
+{{ component /processed/components/_file-box.html }}\
+    {{ define file "source/processed/components/_slots_example.html" }}
+{{ end }}
+
+To use this component is pretty easy:
+
+```html
+<h1>Hello world</h1>
+
+\{{ component /processed/components/_slots_example.html }}
+    \{{ slot top }}This goes at the top\{{ end }}
+    \{{ slot middle }}This goes in the middle\{{ end }}
+    \{{ slot bottom }}This goes at the bottom\{{ end }}
+\{{ end }}
+```
 
 ### A more advanced example
 

--- a/website/source/processed/sections/docs/expression_lang.md
+++ b/website/source/processed/sections/docs/expression_lang.md
@@ -27,10 +27,11 @@ Here's a list of all Magnanimous instructions:
 * [`eval`](#eval)            - evaluates an [expression](#expressions) and inserts the result into the current position.
 * [`include`](#include)      - includes another file into the current position.
 * [`component`](#component)  - includes a [Component](components.html) into the current position.
+* [`slot`](#slot)            - defines a variable whose content is the body of the instruction.
 * [`if`](#if)                - conditionally includes some content into the current position.
 * [`for`](#for)              - repeats some content for each item in an [iterable](#iterables).
 * [`doc`](#doc)              - allows documentation to be added to sources (not included in the resource).
-* [`end`](#end)              - ends a scoped instruction (`component`, `if` and `for`).
+* [`end`](#end)              - ends a scoped instruction (`component`, `slot`, `if` and `for`).
 
 {{ component /processed/components/_linked_header.html }}\
 {{ define id "instructions" }}\
@@ -108,7 +109,7 @@ content:
 <h2>The dog is big</h2>
 ```
 
-Of course, `eval` is mostly useful when combined with variables and expressions.
+Of course, `eval` is mostly useful when combined with variables, [slots](#slot) and expressions.
 
 For example, you could define a number of variables beforehand, to be used later in several other places
 (so you could change them in only one place if you ever changed your mind about their values):
@@ -147,7 +148,7 @@ Example:
 
 ```html
 <div id="other-file-contents">
-{{ include path/to/other/file.md }}
+\{{ include path/to/other/file.md }}
 </div>
 ```
 
@@ -169,13 +170,13 @@ component
 _where:_
 
 * `path` is a [path](#path) to another file.
-* `content` is some content that might be used by the component via the `__contents__` implicit variable.
+* `content` the body of the component.
 
 The `component` instruction is quite similar to `include`. It also includes the contents of another file, 
-the component (which is usually designed specifically for this purpose), into another file.
+the component file (which is usually designed specifically for this purpose), into the file using it.
 
-However, components are more powerful as they may include some content which can be placed anywhere inside the 
-component, or just `define` instructions which can set values that are used to customize the component.
+However, components are more powerful as they may also declare some content which can be placed anywhere inside the 
+component (typically using `slot`s).
 
 Example:
 
@@ -197,6 +198,33 @@ Include this in my component.
 ```
 
 See [Components](components.html) for more details about using components.
+
+{{ component /processed/components/_linked_header.html }}\
+{{ define id "slot" }}{{ define tag "h3" }}\
+slot
+{{ end }}
+
+#### Syntax:
+
+```
+\{{ slot <slot-name> }}
+<content>
+\{{ end }}
+```
+
+_where:_
+
+* `slot-name` the name of this slot.
+* `content` the content the slot evaluates to.
+
+A `slot` instruction, like [`define`](#define), defines a variable and does not include any content at the location where it is
+declared. But unlike `define`, `slot` uses the body of its declaration as it value.
+
+That means that evaluating the `slot` with [`eval`](#eval) results in the body of the slot being inserted into the 
+processed document where the `eval` instruction was located.
+
+Slots are commonly used together with [Components](components.html) (but may also be used on their own), so they are
+explained in more detail in the [Components](components.htlm) page.
 
 {{ component /processed/components/_linked_header.html }}\
 {{ define id "if" }}{{ define tag "h3" }}\

--- a/website/source/processed/sections/docs/expression_lang.md
+++ b/website/source/processed/sections/docs/expression_lang.md
@@ -345,7 +345,13 @@ be set for a [Component](components.html), for example.
 end
 {{ end }}
 
-`end` is not an independent instruction. It is used to end the scope of a previously started scoped instruction.
+#### Syntax:
+
+```
+\{{ end }}
+```
+
+`end` is not an independent instruction; it is used to end the scope of a previously started scoped instruction.
 
 It does not accept any argument.
 
@@ -359,6 +365,9 @@ Scoped instructions are:
 * `for`
 
 Each `end` instruction always matches the nearest unclosed scoped instruction.
+
+{{include /processed/components/_spacer.html }}\
+<hr>
 
 {{ component /processed/components/_linked_header.html }}\
 {{ define id "expressions" }}\

--- a/website/source/processed/sections/docs/expression_lang.md
+++ b/website/source/processed/sections/docs/expression_lang.md
@@ -220,8 +220,8 @@ _where:_
 A `slot` instruction, like [`define`](#define), defines a variable and does not include any content at the location where it is
 declared. But unlike `define`, `slot` uses the body of its declaration as it value.
 
-That means that evaluating the `slot` with [`eval`](#eval) results in the body of the slot being inserted into the 
-processed document where the `eval` instruction was located.
+That means that evaluating the variable defined by `slot` with [`eval`](#eval) results in the body of the slot 
+being inserted into the processed document.
 
 Slots are commonly used together with [Components](components.html) (but may also be used on their own), so they are
 explained in more detail in the [Components](components.htlm) page.
@@ -317,12 +317,12 @@ If you need to pass in an expression, or just a variable instead of a hardcoded 
 \{{ end }}
 ```
 
+See [Iterables](#iterables) for details about what iterable types can be used with the `for` instruction.
+
 {{ component /processed/components/_linked_header.html }}\
 {{ define id "doc" }}{{ define tag "h3" }}\
 doc
 {{ end }}
-
-See [Iterables](#iterables) for details about what iterable types can be used with the `for` instruction.
 
 #### Syntax:
 
@@ -351,7 +351,14 @@ It does not accept any argument.
 
 All scoped instructions must always be finalized with an `\{{ end }}`.
 
-The latest scoped instruction declared in a document is always the first to be terminated by `end`.
+Scoped instructions are:
+
+* `component`
+* `slot`
+* `if`
+* `for`
+
+Each `end` instruction always matches the nearest unclosed scoped instruction.
 
 {{ component /processed/components/_linked_header.html }}\
 {{ define id "expressions" }}\

--- a/website/source/static/css/styles.css
+++ b/website/source/static/css/styles.css
@@ -4,7 +4,7 @@ body {
     line-height: 1.6;
     font-size: 18px;
     color: #444;
-    padding: 0 10px;
+    padding: 10px;
     font-family: Helvetica, sans-serif;
 }
 


### PR DESCRIPTION
Refactored the implementation to make internals simpler.
Made a clear separation between parsing and writing.
Removed context from the parsing phase. Only when writing does context exists.